### PR TITLE
Normalize event dates for get_event and add tests

### DIFF
--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -10,6 +10,51 @@ from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
 
 
+def _normalize_date_str(date_str: str) -> str:
+    """Normalize various ISO date/datetime inputs to YYYY-MM-DD."""
+    if not date_str:
+        return date_str
+
+    # Accept datetime/date objects as well
+    if isinstance(date_str, datetime):
+        return date_str.date().isoformat()
+
+    # Normalize whitespace and ensure string
+    s = str(date_str).strip()
+
+    # Fast-path for already date-only strings
+    if len(s) == 10 and s[4] == "-" and s[7] == "-":
+        return s
+
+    # Try ISO parsing with various fallbacks to be robust against formats
+    try:
+        # datetime.fromisoformat doesn't accept trailing 'Z', replace with +00:00
+        if s.endswith("Z"):
+            s2 = s[:-1] + "+00:00"
+        else:
+            s2 = s
+        dt = datetime.fromisoformat(s2)
+        return dt.date().isoformat()
+    except Exception:
+        # Handle common variations via strptime patterns
+        fmts = [
+            "%Y-%m-%d",
+            "%Y-%m-%dT%H:%M:%S%z",
+            "%Y-%m-%dT%H:%M%z",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%dT%H:%M",
+        ]
+        for fmt in fmts:
+            try:
+                dt = datetime.strptime(s if "%z" not in fmt else (s.replace("Z", "+0000") if s.endswith("Z") else s), fmt)
+                return dt.date().isoformat()
+            except Exception:
+                continue
+
+    # If parsing fails, return original string (best-effort)
+    return s
+
+
 async def get_calendar_events(
     days_ahead: Annotated[int, "Number of days to look ahead"] = 7,
     days_back: Annotated[int, "Number of days to look back"] = 0,
@@ -56,18 +101,24 @@ async def get_calendar_events(
                     },
                 )
 
-            # Sort by date
-            events.sort(key=lambda x: x.start_date_local)
+            # Normalize start dates and sort by date
+            events.sort(key=lambda x: _normalize_date_str(x.start_date_local))
 
             # Group events by date
             events_by_date: dict[str, list[dict[str, Any]]] = {}
             for event in events:
-                date = event.start_date_local
+                date = _normalize_date_str(event.start_date_local)
                 if date not in events_by_date:
                     events_by_date[date] = []
 
                 # Determine relative timing
-                date_obj = datetime.strptime(date, "%Y-%m-%d").date()
+                try:
+                    date_obj = datetime.strptime(date, "%Y-%m-%d").date()
+                except Exception:
+                    # Fall back to parsing any ISO datetime-like string
+                    if date.endswith("Z"):
+                        date = date[:-1] + "+00:00"
+                    date_obj = datetime.fromisoformat(date).date()
                 today = datetime.now().date()
 
                 if date_obj == today:
@@ -183,13 +234,14 @@ async def get_upcoming_workouts(
                     metadata={"message": "No workouts planned on your calendar"},
                 )
 
-            # Sort by date and limit
-            workouts.sort(key=lambda x: x.start_date_local)
+            # Sort by normalized date and limit
+            workouts.sort(key=lambda x: _normalize_date_str(x.start_date_local))
             workouts = workouts[:limit]
 
             workouts_data: list[dict[str, Any]] = []
             for workout in workouts:
-                date_obj = datetime.strptime(workout.start_date_local, "%Y-%m-%d").date()
+                date_str = _normalize_date_str(workout.start_date_local)
+                date_obj = datetime.strptime(date_str, "%Y-%m-%d").date()
                 today = datetime.now().date()
 
                 if date_obj == today:
@@ -201,7 +253,7 @@ async def get_upcoming_workouts(
                     relative_timing = f"in_{days_until}_days"
 
                 workout_item: dict[str, Any] = {
-                    "date": workout.start_date_local,
+                    "date": date_str,
                     "relative_timing": relative_timing,
                     "name": workout.name or "Workout",
                 }
@@ -272,9 +324,12 @@ async def get_event(
         async with ICUClient(config) as client:
             event = await client.get_event(event_id)
 
+            # Normalize date to YYYY-MM-DD so output matches calendar/upcoming_workouts
+            event_date = _normalize_date_str(event.start_date_local)
+
             event_data: dict[str, Any] = {
                 "id": event.id,
-                "date": event.start_date_local,
+                "date": event_date,
                 "name": event.name or event.category or "Event",
                 "category": event.category,
             }

--- a/tests/test_events_tools.py
+++ b/tests/test_events_tools.py
@@ -1,0 +1,150 @@
+"""Tests for calendar/event tools."""
+
+import json
+from unittest.mock import MagicMock
+
+from httpx import Response
+
+from intervals_icu_mcp.tools.events import get_calendar_events, get_upcoming_workouts, get_event
+
+
+async def test_get_calendar_events_handles_iso_datetime(mock_config, respx_mock):
+    """Ensure get_calendar_events accepts full ISO datetimes (with time/Z) and date-only strings."""
+    mock_ctx = MagicMock()
+    mock_ctx.get_state.return_value = mock_config
+
+    events_payload = [
+        {
+            "id": 1001,
+            "start_date_local": "2025-10-14T08:00:00Z",
+            "category": "WORKOUT",
+            "name": "Threshold Intervals",
+            "type": "Ride",
+        },
+        {
+            "id": 1002,
+            "start_date_local": "2025-10-15",
+            "category": "NOTE",
+            "name": "Note",
+        },
+    ]
+
+    respx_mock.get("/athlete/i123456/events").mock(return_value=Response(200, json=events_payload))
+
+    result = await get_calendar_events(ctx=mock_ctx)
+    response = json.loads(result)
+
+    assert "data" in response
+    assert "events_by_date" in response["data"]
+    assert "2025-10-14" in response["data"]["events_by_date"]
+    assert response["data"]["summary"]["total_events"] == 2
+
+
+async def test_get_upcoming_workouts_handles_iso_datetime(mock_config, respx_mock):
+    """Ensure get_upcoming_workouts accepts ISO datetimes and returns workouts with normalized dates."""
+    mock_ctx = MagicMock()
+    mock_ctx.get_state.return_value = mock_config
+
+    events_payload = [
+        {
+            "id": 2001,
+            "start_date_local": "2025-11-01T06:30:00",
+            "category": "WORKOUT",
+            "name": "Easy Ride",
+            "moving_time": 3600,
+        },
+        {
+            "id": 2002,
+            "start_date_local": "2025-11-03",
+            "category": "WORKOUT",
+            "name": "Long Run",
+        },
+    ]
+
+    respx_mock.get("/athlete/i123456/events").mock(return_value=Response(200, json=events_payload))
+
+    result = await get_upcoming_workouts(ctx=mock_ctx)
+    response = json.loads(result)
+
+    assert "data" in response
+    assert "workouts" in response["data"]
+    assert any(w["date"] == "2025-11-01" for w in response["data"]["workouts"]) is True
+    assert any(w["date"] == "2025-11-03" for w in response["data"]["workouts"]) is True
+    assert response["data"]["count"] == 2
+
+
+async def test_various_datetime_formats_are_normalized_for_calendar_and_workouts(mock_config, respx_mock):
+    """Ensure various ISO datetime variants are accepted and normalized to YYYY-MM-DD."""
+    mock_ctx = MagicMock()
+    mock_ctx.get_state.return_value = mock_config
+
+    events_payload = [
+        {
+            "id": 3001,
+            "start_date_local": "2025-12-01T08:00Z",
+            "category": "WORKOUT",
+            "name": "Zulu Ride",
+        },
+        {
+            "id": 3002,
+            "start_date_local": "2025-12-02T08:00:00.123Z",
+            "category": "WORKOUT",
+            "name": "Millis Ride",
+        },
+        {
+            "id": 3003,
+            "start_date_local": "2025-12-03T08:00+00:00",
+            "category": "WORKOUT",
+            "name": "Offset Ride",
+        },
+        {
+            "id": 3004,
+            "start_date_local": "2025-12-05",
+            "category": "NOTE",
+            "name": "Date-only Note",
+        },
+    ]
+
+    respx_mock.get("/athlete/i123456/events").mock(return_value=Response(200, json=events_payload))
+
+    # Calendar should group events by normalized date
+    cal_result = await get_calendar_events(ctx=mock_ctx)
+    cal_resp = json.loads(cal_result)
+    assert "2025-12-01" in cal_resp["data"]["events_by_date"]
+    assert "2025-12-02" in cal_resp["data"]["events_by_date"]
+    assert "2025-12-03" in cal_resp["data"]["events_by_date"]
+    assert "2025-12-05" in cal_resp["data"]["events_by_date"]
+
+    # Upcoming workouts should have normalized dates
+    wk_result = await get_upcoming_workouts(ctx=mock_ctx)
+    wk_resp = json.loads(wk_result)
+    assert any(w["date"] == "2025-12-01" for w in wk_resp["data"]["workouts"]) is True
+    assert any(w["date"] == "2025-12-02" for w in wk_resp["data"]["workouts"]) is True
+    assert any(w["date"] == "2025-12-03" for w in wk_resp["data"]["workouts"]) is True
+
+
+async def test_get_event_normalizes_date(mock_config, respx_mock):
+    """Ensure single event fetch normalizes various ISO date inputs to YYYY-MM-DD."""
+    mock_ctx = MagicMock()
+    mock_ctx.get_state.return_value = mock_config
+
+    payloads = [
+        (4001, "2025-12-01T08:00Z", "2025-12-01"),
+        (4002, "2025-12-02T08:00:00.123Z", "2025-12-02"),
+    ]
+
+    for eid, start, expected in payloads:
+        event_payload = {
+            "id": eid,
+            "start_date_local": start,
+            "category": "WORKOUT",
+            "name": "Normalized Event",
+        }
+
+        respx_mock.get(f"/athlete/i123456/events/{eid}").mock(return_value=Response(200, json=event_payload))
+
+        result = await get_event(eid, ctx=mock_ctx)
+        resp = json.loads(result)
+
+        assert "data" in resp
+        assert resp["data"]["date"] == expected


### PR DESCRIPTION
Ensure `get_event` returns normalized YYYY-MM-DD dates and add tests for ISO datetime variants. This fixes parsing issues when `start_date_local` contains full ISO datetimes (e.g., with "Z" or fractional seconds).

Fixes #1