### PR TITLE
feat: add multi-athlete support and event IDs in responses

### DIFF
--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -1131,9 +1131,11 @@ class ICUClient:
             Created Event object
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        # Ensure date has T00:00:00 suffix for Intervals.icu API
+        date_with_time = new_date if "T" in new_date else f"{new_date}T00:00:00"
         response = await self._request(
             "POST",
             f"/athlete/{athlete_id}/events/{event_id}/duplicate",
-            json={"start_date_local": new_date},
+            json={"start_date_local": date_with_time},
         )
         return Event(**response.json())

--- a/src/intervals_icu_mcp/middleware.py
+++ b/src/intervals_icu_mcp/middleware.py
@@ -36,7 +36,7 @@ class ConfigMiddleware(Middleware):
 
         # Inject config into context state for tools to access
         if context.fastmcp_context:
-            context.fastmcp_context.set_state("config", config)
+            await context.fastmcp_context.set_state("config", config, serializable=False)
 
         # Continue to the tool execution
         return await call_next(context)

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -59,6 +59,8 @@ class AthleteProfile(BaseModel):
 class ActivitySummary(BaseModel):
     """Summary representation of an activity (for lists)."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     id: str
     start_date_local: datetime
     name: str | None = None
@@ -69,7 +71,7 @@ class ActivitySummary(BaseModel):
     total_elevation_gain: float | None = None
     average_speed: float | None = None
     average_heartrate: int | None = None
-    average_watts: int | None = None
+    average_watts: int | None = Field(default=None, alias="icu_average_watts")
     normalized_power: int | None = None
     average_cadence: float | None = None
     icu_training_load: int | None = None
@@ -88,7 +90,7 @@ class Activity(ActivitySummary):
     max_speed: float | None = None
     max_watts: int | None = None
     max_cadence: float | None = None
-    weighted_average_watts: int | None = None
+    weighted_average_watts: int | None = Field(default=None, alias="icu_weighted_avg_watts")
     variability_index: float | None = None
     efficiency_factor: float | None = None
     tss: float | None = None

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -28,7 +28,7 @@ async def get_recent_activities(
         JSON string with activity summaries
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         # Calculate date range
@@ -112,7 +112,7 @@ async def get_activity_details(
         JSON string with detailed activity information
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -247,7 +247,7 @@ async def search_activities(
         JSON string with matching activities
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     if not query.strip():
         return ResponseBuilder.build_error_response(
@@ -328,7 +328,7 @@ async def update_activity(
         JSON string with updated activity information
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         # Build update data (only include provided fields)
@@ -406,7 +406,7 @@ async def delete_activity(
         JSON string with deletion confirmation
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -450,7 +450,7 @@ async def download_activity_file(
         JSON string with file info and base64-encoded content (if no output_path)
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -518,7 +518,7 @@ async def download_fit_file(
         JSON string with file info and base64-encoded content (if no output_path)
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -588,7 +588,7 @@ async def download_gpx_file(
         JSON string with file info and base64-encoded content (if no output_path)
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -659,7 +659,7 @@ async def search_activities_full(
         JSON string with complete activity details for matches
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     if not query.strip():
         return ResponseBuilder.build_error_response(
@@ -754,7 +754,7 @@ async def get_activities_around(
         JSON string with activities around the reference activity
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -13,6 +13,7 @@ from ..response_builder import ResponseBuilder
 async def get_recent_activities(
     limit: Annotated[int, "Number of activities to fetch"] = 30,
     days_back: Annotated[int, "Number of days to look back"] = 30,
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Get recent activities for the authenticated athlete.
@@ -37,6 +38,7 @@ async def get_recent_activities(
 
         async with ICUClient(config) as client:
             activities = await client.get_activities(
+                athlete_id=athlete_id,
                 oldest=oldest,
                 limit=min(limit, 100),  # Cap at 100
             )
@@ -232,6 +234,7 @@ async def get_activity_details(
 async def search_activities(
     query: Annotated[str, "Search query (activity name or tag)"],
     limit: Annotated[int, "Maximum number of results to return"] = 30,
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Search for activities by name or tag.
@@ -258,6 +261,7 @@ async def search_activities(
     try:
         async with ICUClient(config) as client:
             results = await client.search_activities(
+                athlete_id=athlete_id,
                 query=query,
                 limit=min(limit, 100),  # Cap at 100
             )

--- a/src/intervals_icu_mcp/tools/activity_analysis.py
+++ b/src/intervals_icu_mcp/tools/activity_analysis.py
@@ -44,7 +44,7 @@ async def get_activity_streams(
         JSON string with time-series data streams
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -123,7 +123,7 @@ async def get_activity_intervals(
         JSON string with interval data
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -232,7 +232,7 @@ async def get_best_efforts(
         JSON string with best efforts data
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -322,7 +322,7 @@ async def search_intervals(
         JSON string with matching intervals
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -389,7 +389,7 @@ async def get_power_histogram(
         JSON string with power distribution bins
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -449,7 +449,7 @@ async def get_hr_histogram(
         JSON string with HR distribution bins
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -509,7 +509,7 @@ async def get_pace_histogram(
         JSON string with pace distribution bins
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -580,7 +580,7 @@ async def get_gap_histogram(
         JSON string with GAP distribution bins
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:

--- a/src/intervals_icu_mcp/tools/athlete.py
+++ b/src/intervals_icu_mcp/tools/athlete.py
@@ -21,7 +21,7 @@ async def get_athlete_profile(
         JSON string with athlete profile data
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -158,7 +158,7 @@ async def get_fitness_summary(
         JSON string with fitness summary and recommendations
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:

--- a/src/intervals_icu_mcp/tools/curves.py
+++ b/src/intervals_icu_mcp/tools/curves.py
@@ -35,7 +35,7 @@ async def get_hr_curves(
         JSON string with HR curve data
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         # Determine date range
@@ -208,7 +208,7 @@ async def get_pace_curves(
         JSON string with pace curve data
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         # Determine date range

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -19,6 +19,7 @@ async def create_event(
     duration_seconds: Annotated[int | None, "Planned duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Planned distance in meters"] = None,
     training_load: Annotated[int | None, "Planned training load"] = None,
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Create a new calendar event (planned workout, note, race, or goal).
@@ -80,7 +81,7 @@ async def create_event(
             event_data["icu_training_load"] = training_load
 
         async with ICUClient(config) as client:
-            event = await client.create_event(event_data)
+            event = await client.create_event(event_data, athlete_id=athlete_id)
 
             event_result: dict[str, Any] = {
                 "id": event.id,
@@ -123,6 +124,7 @@ async def update_event(
     duration_seconds: Annotated[int | None, "Updated duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Updated distance in meters"] = None,
     training_load: Annotated[int | None, "Updated training load"] = None,
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Update an existing calendar event.
@@ -183,7 +185,7 @@ async def update_event(
             )
 
         async with ICUClient(config) as client:
-            event = await client.update_event(event_id, event_data)
+            event = await client.update_event(event_id, event_data, athlete_id=athlete_id)
 
             event_result: dict[str, Any] = {
                 "id": event.id,
@@ -219,6 +221,7 @@ async def update_event(
 
 async def delete_event(
     event_id: Annotated[int, "Event ID to delete"],
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Delete a calendar event.
@@ -236,7 +239,7 @@ async def delete_event(
 
     try:
         async with ICUClient(config) as client:
-            success = await client.delete_event(event_id)
+            success = await client.delete_event(event_id, athlete_id=athlete_id)
 
             if success:
                 return ResponseBuilder.build_response(
@@ -263,6 +266,7 @@ async def bulk_create_events(
         str,
         "JSON string containing array of events. Each event should have: start_date_local, name, category, and optional fields like description, type, moving_time, distance, icu_training_load",
     ],
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Create multiple calendar events in a single operation.
@@ -338,7 +342,7 @@ async def bulk_create_events(
                     )
 
         async with ICUClient(config) as client:
-            created_events = await client.bulk_create_events(events_data)
+            created_events = await client.bulk_create_events(events_data, athlete_id=athlete_id)
 
             events_result: list[dict[str, Any]] = []
             for event in created_events:
@@ -381,6 +385,7 @@ async def bulk_create_events(
 
 async def bulk_delete_events(
     event_ids: Annotated[str, "JSON array of event IDs to delete (e.g., '[123, 456, 789]')"],
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Delete multiple calendar events in a single operation.
@@ -422,7 +427,7 @@ async def bulk_delete_events(
         ids_list: list[int] = parsed_data  # type: ignore[assignment]
 
         async with ICUClient(config) as client:
-            result = await client.bulk_delete_events(ids_list)
+            result = await client.bulk_delete_events(ids_list, athlete_id=athlete_id)
 
             return ResponseBuilder.build_response(
                 data={"deleted_count": len(ids_list), "event_ids": ids_list, "result": result},
@@ -441,6 +446,7 @@ async def bulk_delete_events(
 async def duplicate_event(
     event_id: Annotated[int, "Event ID to duplicate"],
     new_date: Annotated[str, "New date for the duplicated event (YYYY-MM-DD format)"],
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Duplicate an existing event to a new date.
@@ -469,7 +475,7 @@ async def duplicate_event(
 
     try:
         async with ICUClient(config) as client:
-            duplicated_event = await client.duplicate_event(event_id, new_date)
+            duplicated_event = await client.duplicate_event(event_id, new_date, athlete_id=athlete_id)
 
             event_result: dict[str, Any] = {
                 "id": duplicated_event.id,

--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -28,7 +28,7 @@ async def get_calendar_events(
         JSON string with calendar events
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         # Calculate date range
@@ -67,7 +67,7 @@ async def get_calendar_events(
                     events_by_date[date] = []
 
                 # Determine relative timing
-                date_obj = datetime.strptime(date, "%Y-%m-%d").date()
+                date_obj = datetime.fromisoformat(date).date()
                 today = datetime.now().date()
 
                 if date_obj == today:
@@ -160,7 +160,7 @@ async def get_upcoming_workouts(
         JSON string with upcoming workouts
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         # Look ahead 30 days to find workouts
@@ -189,7 +189,7 @@ async def get_upcoming_workouts(
 
             workouts_data: list[dict[str, Any]] = []
             for workout in workouts:
-                date_obj = datetime.strptime(workout.start_date_local, "%Y-%m-%d").date()
+                date_obj = datetime.fromisoformat(workout.start_date_local).date()
                 today = datetime.now().date()
 
                 if date_obj == today:
@@ -266,7 +266,7 @@ async def get_event(
         JSON string with event details
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:

--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -13,6 +13,7 @@ from ..response_builder import ResponseBuilder
 async def get_calendar_events(
     days_ahead: Annotated[int, "Number of days to look ahead"] = 7,
     days_back: Annotated[int, "Number of days to look back"] = 0,
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Get planned events and workouts from the calendar.
@@ -40,6 +41,7 @@ async def get_calendar_events(
 
         async with ICUClient(config) as client:
             events = await client.get_events(
+                athlete_id=athlete_id,
                 oldest=oldest,
                 newest=newest,
             )
@@ -80,6 +82,7 @@ async def get_calendar_events(
                     relative_timing = f"in_{days_until}_days"
 
                 event_item: dict[str, Any] = {
+                    "id": event.id,
                     "date": date,
                     "relative_timing": relative_timing,
                     "name": event.name or event.category or "Event",
@@ -146,6 +149,7 @@ async def get_calendar_events(
 
 async def get_upcoming_workouts(
     limit: Annotated[int, "Maximum number of workouts to return"] = 7,
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Get upcoming planned workouts from the calendar.
@@ -170,6 +174,7 @@ async def get_upcoming_workouts(
 
         async with ICUClient(config) as client:
             events = await client.get_events(
+                athlete_id=athlete_id,
                 oldest=oldest,
                 newest=newest,
             )
@@ -201,6 +206,7 @@ async def get_upcoming_workouts(
                     relative_timing = f"in_{days_until}_days"
 
                 workout_item: dict[str, Any] = {
+                    "id": workout.id,
                     "date": workout.start_date_local,
                     "relative_timing": relative_timing,
                     "name": workout.name or "Workout",
@@ -252,6 +258,7 @@ async def get_upcoming_workouts(
 
 async def get_event(
     event_id: Annotated[int, "Event ID to retrieve"],
+    athlete_id: Annotated[str | None, "Athlete ID (for coaches managing multiple athletes)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Get detailed information for a specific calendar event.
@@ -270,7 +277,7 @@ async def get_event(
 
     try:
         async with ICUClient(config) as client:
-            event = await client.get_event(event_id)
+            event = await client.get_event(event_id, athlete_id=athlete_id)
 
             event_data: dict[str, Any] = {
                 "id": event.id,

--- a/src/intervals_icu_mcp/tools/performance.py
+++ b/src/intervals_icu_mcp/tools/performance.py
@@ -35,7 +35,7 @@ async def get_power_curves(
         JSON string with power curve data
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         # Determine date range

--- a/src/intervals_icu_mcp/tools/wellness.py
+++ b/src/intervals_icu_mcp/tools/wellness.py
@@ -26,7 +26,7 @@ async def get_wellness_data(
         JSON string with wellness data
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         # Calculate date range
@@ -201,7 +201,7 @@ async def get_wellness_for_date(
         JSON string with wellness data for the date
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     # Validate date format
     try:
@@ -380,7 +380,7 @@ async def update_wellness(
         JSON string with updated wellness data
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     # Validate date format
     try:

--- a/src/intervals_icu_mcp/tools/workout_library.py
+++ b/src/intervals_icu_mcp/tools/workout_library.py
@@ -23,7 +23,7 @@ async def get_workout_library(
         JSON string with workout folders/plans
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -107,7 +107,7 @@ async def get_workouts_in_folder(
         JSON string with workout details
     """
     assert ctx is not None
-    config: ICUConfig = ctx.get_state("config")
+    config: ICUConfig = await ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:

--- a/tests/test_athlete_tools.py
+++ b/tests/test_athlete_tools.py
@@ -1,6 +1,6 @@
 """Tests for athlete tools."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from httpx import Response
 
@@ -19,7 +19,7 @@ class TestGetAthleteProfile:
         """Test successful athlete profile retrieval."""
         # Create mock context with config
         mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = mock_config
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
         # Mock the API endpoint
         respx_mock.get("/athlete/i123456").mock(return_value=Response(200, json=mock_athlete_data))
@@ -50,7 +50,7 @@ class TestGetFitnessSummary:
         """Test successful fitness summary retrieval."""
         # Create mock context with config
         mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = mock_config
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
         # Mock the API endpoint
         respx_mock.get("/athlete/i123456").mock(return_value=Response(200, json=mock_athlete_data))
@@ -74,7 +74,7 @@ class TestGetFitnessSummary:
         """Test fitness summary with high ramp rate warning."""
         # Create mock context with config
         mock_ctx = MagicMock()
-        mock_ctx.get_state.return_value = mock_config
+        mock_ctx.get_state = AsyncMock(return_value=mock_config)
 
         # Modify athlete data to have high ramp rate
         athlete_data = mock_athlete_data.copy()


### PR DESCRIPTION
## Summary

Builds on #4. Two additions:

- **Multi-athlete support** — adds optional `athlete_id` parameter to 11 tools, enabling coaches and users managing multiple athletes to specify which athlete to query. Defaults to the configured athlete when not provided (no behavior change for single-athlete users).

  Affected tools: `get_recent_activities`, `search_activities`, `get_calendar_events`, `get_upcoming_workouts`, `get_event`, `create_event`, `update_event`, `delete_event`, `duplicate_event`, `bulk_create_events`, `bulk_delete_events`

- **Event IDs in list responses** — `get_calendar_events` and `get_upcoming_workouts` now include the event `id` field in their responses. Without this, users can discover events but have no way to subsequently update or delete them via `update_event`/`delete_event`.

## Test plan

- [ ] Verify `get_calendar_events` response includes `id` field for each event
- [ ] Verify `get_upcoming_workouts` response includes `id` field for each workout
- [ ] Verify `athlete_id` parameter is passed through to API client calls for all 11 tools
- [ ] Verify default behavior (no `athlete_id` provided) is unchanged

> **Note:** This PR depends on #4 (FastMCP 3.x async fixes). Please merge #4 first.