### PR TITLE
fix: resolve date parsing issues in event tools

### DIFF
--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -50,12 +50,12 @@ async def create_event(
             error_type="validation_error",
         )
 
-    # Validate date format
+    # Validate and normalize date format (accept YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
     try:
-        datetime.strptime(start_date, "%Y-%m-%d")
+        start_date = datetime.fromisoformat(start_date).strftime("%Y-%m-%dT%H:%M:%S")
     except ValueError:
         return ResponseBuilder.build_error_response(
-            "Invalid date format. Please use YYYY-MM-DD format.",
+            "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
             error_type="validation_error",
         )
 
@@ -145,13 +145,13 @@ async def update_event(
     assert ctx is not None
     config: ICUConfig = ctx.get_state("config")
 
-    # Validate date format if provided
+    # Validate and normalize date format if provided (accept YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
     if start_date:
         try:
-            datetime.strptime(start_date, "%Y-%m-%d")
+            start_date = datetime.fromisoformat(start_date).strftime("%Y-%m-%dT%H:%M:%S")
         except ValueError:
             return ResponseBuilder.build_error_response(
-                "Invalid date format. Please use YYYY-MM-DD format.",
+                "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
                 error_type="validation_error",
             )
 
@@ -322,12 +322,14 @@ async def bulk_create_events(
             # Normalize category to uppercase
             event_data["category"] = event_data["category"].upper()
 
-            # Validate date format
+            # Validate and normalize date format (accept YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
             try:
-                datetime.strptime(event_data["start_date_local"], "%Y-%m-%d")
+                event_data["start_date_local"] = datetime.fromisoformat(
+                    event_data["start_date_local"]
+                ).strftime("%Y-%m-%dT%H:%M:%S")
             except ValueError:
                 return ResponseBuilder.build_error_response(
-                    f"Event {i}: Invalid date format. Please use YYYY-MM-DD format.",
+                    f"Event {i}: Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
                     error_type="validation_error",
                 )
 
@@ -452,12 +454,12 @@ async def duplicate_event(
     assert ctx is not None
     config: ICUConfig = ctx.get_state("config")
 
-    # Validate date format
+    # Validate and normalize date format (accept YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS)
     try:
-        datetime.strptime(new_date, "%Y-%m-%d")
+        new_date = datetime.fromisoformat(new_date).strftime("%Y-%m-%dT%H:%M:%S")
     except ValueError:
         return ResponseBuilder.build_error_response(
-            "Invalid date format. Please use YYYY-MM-DD format.",
+            "Invalid date format. Please use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS format.",
             error_type="validation_error",
         )
 

--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -67,7 +67,7 @@ async def get_calendar_events(
                     events_by_date[date] = []
 
                 # Determine relative timing
-                date_obj = datetime.strptime(date, "%Y-%m-%d").date()
+                date_obj = datetime.fromisoformat(date).date()
                 today = datetime.now().date()
 
                 if date_obj == today:
@@ -189,7 +189,7 @@ async def get_upcoming_workouts(
 
             workouts_data: list[dict[str, Any]] = []
             for workout in workouts:
-                date_obj = datetime.strptime(workout.start_date_local, "%Y-%m-%d").date()
+                date_obj = datetime.fromisoformat(workout.start_date_local).date()
                 today = datetime.now().date()
 
                 if date_obj == today:


### PR DESCRIPTION
## Summary

- **Bug 1** (`get_calendar_events`, `get_upcoming_workouts`): Replace `datetime.strptime(date, "%Y-%m-%d")` with `datetime.fromisoformat(date)` in `events.py` so that API responses containing `YYYY-MM-DDTHH:MM:SS` no longer crash with `"unconverted data remains"`.

- **Bug 2** (`create_event`, `update_event`, `bulk_create_events`, `duplicate_event`): Update date validation in `event_management.py` to accept both `YYYY-MM-DD` and `YYYY-MM-DDTHH:MM:SS` input, then normalize to full datetime (`YYYY-MM-DDTHH:MM:SS`) before sending to the API (which requires the full format).

## Root cause

Inconsistent date format handling between:
- **API responses** → `YYYY-MM-DDTHH:MM:SS` (what the API returns)
- **API requests** → `YYYY-MM-DDTHH:MM:SS` (what the API expects to receive)
- **Tool validation** → `YYYY-MM-DD` only (what the tools previously accepted/parsed)

## Test plan

- [ ] `get_calendar_events` / `get_upcoming_workouts` no longer crash when API returns `YYYY-MM-DDTHH:MM:SS` dates
- [ ] `create_event` with `start_date="2026-03-01"` sends `"2026-03-01T00:00:00"` to the API and succeeds
- [ ] `create_event` with `start_date="2026-03-01T10:00:00"` is now accepted (previously rejected)
- [ ] `update_event`, `bulk_create_events`, `duplicate_event` apply the same normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)