### PR TITLE
Fix/feat: correct API bugs, add 27 new tools for workout library, folders, and training plans          

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is an MCP (Model Context Protocol) server for Intervals.icu that provides 40+ tools, 1 resource, and 6 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs.
+This is an MCP (Model Context Protocol) server for Intervals.icu that provides 67 tools, 1 resource, and 6 prompts for accessing training data, wellness metrics, and performance analysis through Claude and other LLMs.
 
 ## Development Commands
 
@@ -114,19 +114,21 @@ make docker/run
 
 ### Tool Organization
 
-Tools are organized into 7 categories in `tools/`:
+Tools are organized into 13 modules in `tools/`:
 
 1. **activities.py** - Query and manage activities
 2. **activity_analysis.py** - Streams, intervals, best efforts
 3. **athlete.py** - Profile and fitness metrics (CTL/ATL/TSB)
 4. **wellness.py** - HRV, sleep, recovery metrics
 5. **events.py** - Calendar queries
-6. **event_management.py** - Create/update/delete events
+6. **event_management.py** - Create/update/delete events; supports `workout_doc`, tags, indoor, target, all 14 event categories
 7. **performance.py** - Power/HR/pace curves
 8. **curves.py** - HR and pace curve analysis
-9. **workout_library.py** - Browse workout folders and plans
-10. **gear.py** - Manage gear and reminders
-11. **sport_settings.py** - FTP, FTHR, pace thresholds
+9. **workout_library.py** - Full workout CRUD, file import/export (.zwo/.mrc/.erg/.fit), tags, duplication
+10. **folder_management.py** - Create/update/delete folders and training plans, folder sharing
+11. **training_plan.py** - Assign training plans to athletes, apply plan changes to calendar
+12. **gear.py** - Manage gear and reminders
+13. **sport_settings.py** - FTP, FTHR, pace thresholds
 
 ### Tool Pattern
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Multi-stage build for minimal final image
-FROM --platform=$TARGETPLATFORM ghcr.io/astral-sh/uv:latest AS uv
+FROM ghcr.io/astral-sh/uv:latest AS uv
 
-FROM --platform=$TARGETPLATFORM python:3.11-slim AS builder
+FROM python:3.11-slim AS builder
 
 # Install uv for faster dependency management
 COPY --from=uv /uv /usr/local/bin/uv
@@ -19,7 +19,7 @@ COPY src/ ./src/
 RUN uv sync --frozen --no-dev
 
 # Final stage - minimal runtime image
-FROM --platform=$TARGETPLATFORM python:3.11-slim
+FROM python:3.11-slim
 
 # Set working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -8,15 +8,17 @@ A Model Context Protocol (MCP) server for Intervals.icu integration. Access your
 
 ## Overview
 
-This MCP server provides 48 tools to interact with your Intervals.icu account, organized into 9 categories:
+This MCP server provides 67 tools to interact with your Intervals.icu account, organized into 12 categories:
 
 - Activities (10 tools) - Query, search, update, delete, and download activities
 - Activity Analysis (8 tools) - Deep dive into streams, intervals, best efforts, and histograms
 - Athlete (2 tools) - Access profile, fitness metrics, and training load
 - Wellness (3 tools) - Track and update recovery, HRV, sleep, and health metrics
-- Events/Calendar (9 tools) - Manage planned workouts, races, notes with bulk operations
+- Events/Calendar (9 tools) - Manage planned workouts, races, notes with bulk operations and structured workout support
 - Performance/Curves (3 tools) - Analyze power, heart rate, and pace curves
-- Workout Library (2 tools) - Browse and explore workout templates and plans
+- Workout Library (12 tools) - Full CRUD for workouts, file import/export, tags, and duplication
+- Folder Management (6 tools) - Create and manage workout folders and training plans with sharing
+- Training Plan (3 tools) - Assign training plans and sync them to the calendar
 - Gear Management (6 tools) - Track equipment and maintenance reminders
 - Sport Settings (5 tools) - Configure FTP, FTHR, pace thresholds, and zones
 
@@ -209,10 +211,37 @@ _Note: The athlete profile resource (`intervals-icu://athlete/profile`) automati
 ```
 "What workouts do I have planned this week?"
 "Create a threshold workout for tomorrow"
-"Update my workout on Friday"
+"Update my workout on Friday - change it to a recovery ride"
 "Delete the workout on Saturday"
 "Duplicate this week's plan for next week"
 "Create 5 workouts for my build phase"
+"Create a structured 3x10min threshold workout with power targets"
+"Schedule a race A event on June 15th"
+"Mark next Monday as a rest day"
+```
+
+### Workout Library
+
+```
+"Show me my workout library"
+"What workouts are in my threshold folder?"
+"Create a new structured 5x5min VO2max workout in my interval folder"
+"Update the workout_doc for my FTP test workout"
+"Import this .zwo file into my library"
+"Export my threshold workout as a .zwo file"
+"Duplicate my base week workouts 4 times with 1 week between"
+"What tags do I use in my workout library?"
+```
+
+### Folder & Training Plan Management
+
+```
+"Create a new 16-week base build training plan"
+"Show me which athletes I've shared my plan with"
+"Share my training plan with my coach"
+"What training plan am I currently on?"
+"Switch me to the 12-week race prep plan starting May 1st"
+"Apply my training plan changes to my calendar"
 ```
 
 ### Performance Analysis
@@ -221,13 +250,6 @@ _Note: The athlete profile resource (`intervals-icu://athlete/profile`) automati
 "What's my 20-minute power and FTP?"
 "Show me my heart rate zones"
 "Analyze my running pace curve"
-```
-
-### Workout Library
-
-```
-"Show me my workout library"
-"What workouts are in my threshold folder?"
 ```
 
 ### Gear Management
@@ -295,17 +317,19 @@ _Note: The athlete profile resource (`intervals-icu://athlete/profile`) automati
 
 ### Events/Calendar (9 tools)
 
-| Tool                    | Description                                                |
-| ----------------------- | ---------------------------------------------------------- |
-| `get-calendar-events`   | Get planned events and workouts from calendar              |
-| `get-upcoming-workouts` | Get upcoming planned workouts only                         |
-| `get-event`             | Get details for a specific event                           |
-| `create-event`          | Create new calendar events (workouts, races, notes, goals) |
-| `update-event`          | Modify existing calendar events                            |
-| `delete-event`          | Remove events from calendar                                |
-| `bulk-create-events`    | Create multiple events in a single operation               |
-| `bulk-delete-events`    | Delete multiple events in a single operation               |
-| `duplicate-event`       | Duplicate an event to a new date                           |
+| Tool                    | Description                                                                                               |
+| ----------------------- | --------------------------------------------------------------------------------------------------------- |
+| `get-calendar-events`   | Get planned events and workouts from calendar                                                             |
+| `get-upcoming-workouts` | Get upcoming planned workouts only                                                                        |
+| `get-event`             | Get details for a specific event                                                                          |
+| `create-event`          | Create events with all 14 categories, structured `workout_doc`, tags, indoor flag, and target metric      |
+| `update-event`          | Modify existing events including workout structure, tags, and targets                                     |
+| `delete-event`          | Remove events from calendar                                                                               |
+| `bulk-create-events`    | Create multiple events in a single operation                                                              |
+| `bulk-delete-events`    | Delete multiple events in a single operation                                                              |
+| `duplicate-event`       | Duplicate an event (including its workout structure) to a new date                                        |
+
+Supported event categories: `WORKOUT`, `RACE_A`, `RACE_B`, `RACE_C`, `NOTE`, `PLAN`, `HOLIDAY`, `SICK`, `INJURED`, `SET_EFTP`, `FITNESS_DAYS`, `SEASON_START`, `TARGET`, `SET_FITNESS`
 
 ### Performance/Curves (3 tools)
 
@@ -315,12 +339,41 @@ _Note: The athlete profile resource (`intervals-icu://athlete/profile`) automati
 | `get-hr-curves`    | Analyze heart rate curves with HR zones                  |
 | `get-pace-curves`  | Analyze running/swimming pace curves with optional GAP   |
 
-### Workout Library (2 tools)
+### Workout Library (12 tools)
 
-| Tool                     | Description                               |
-| ------------------------ | ----------------------------------------- |
-| `get-workout-library`    | Browse workout folders and training plans |
-| `get-workouts-in-folder` | View all workouts in a specific folder    |
+| Tool                     | Description                                                                 |
+| ------------------------ | --------------------------------------------------------------------------- |
+| `get-workout-library`    | Browse workout folders and training plans                                   |
+| `get-workouts-in-folder` | View all workouts in a specific folder                                      |
+| `get-workout`            | Get full details for a single workout including structured `workout_doc`    |
+| `create-workout`         | Create a workout in a folder with optional intervals and power/HR/pace targets |
+| `update-workout`         | Update workout fields, structure, tags, or visibility                       |
+| `delete-workout`         | Delete a workout (optionally including related plan copies)                 |
+| `bulk-create-workouts`   | Create multiple workouts in a single operation                              |
+| `get-workout-tags`       | List all tags used across the workout library                               |
+| `duplicate-workouts`     | Duplicate workouts on a training plan with configurable spacing             |
+| `import-workout`         | Import a .zwo, .mrc, .erg, or .fit file into a folder (base64 input)       |
+| `export-workout`         | Convert a workout to .zwo, .mrc, .erg, or .fit format (base64 output)      |
+| `download-all-workouts`  | Download all workouts as a ZIP archive (base64 output)                      |
+
+### Folder Management (6 tools)
+
+| Tool                    | Description                                                              |
+| ----------------------- | ------------------------------------------------------------------------ |
+| `create-folder`         | Create a workout folder or training plan (FOLDER or PLAN type)           |
+| `update-folder`         | Update folder metadata, visibility, or plan settings                     |
+| `delete-folder`         | Delete a folder and all its workouts                                     |
+| `update-plan-workouts`  | Batch update workouts on a plan (e.g., hide from athlete) with date range |
+| `get-folder-sharing`    | List athletes a folder is shared with                                    |
+| `update-folder-sharing` | Add or remove athletes from a folder's share list                        |
+
+### Training Plan (3 tools)
+
+| Tool                  | Description                                                        |
+| --------------------- | ------------------------------------------------------------------ |
+| `get-training-plan`   | Get the athlete's current training plan assignment                 |
+| `set-training-plan`   | Assign or change the active training plan with a start date        |
+| `apply-plan-changes`  | Sync pending training plan changes to the athlete's calendar       |
 
 ### Gear Management (6 tools)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  intervals-icu-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: intervals-icu-mcp
+    restart: unless-stopped
+    ports:
+      - "8765:8765"
+    env_file:
+      - .env
+    environment:
+      # Use streamable-http transport for remote access
+      - MCP_TRANSPORT=streamable-http
+      # FastMCP reads these via pydantic-settings (FASTMCP_ prefix)
+      - FASTMCP_HOST=0.0.0.0
+      - FASTMCP_PORT=8765
+      - FASTMCP_LOG_LEVEL=INFO
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/')"]
+      interval: 60s
+      timeout: 10s
+      retries: 3
+      start_period: 15s

--- a/docs/remote-deployment.md
+++ b/docs/remote-deployment.md
@@ -1,0 +1,124 @@
+# Remote Deployment via Docker + Tailscale
+
+Deploy the intervals-icu-mcp server on a NAS or remote host for access from Claude Desktop, Claude Code, or any MCP client.
+
+## Architecture
+
+```
+Claude Desktop / Claude Code (anywhere)
+    |
+    v  Tailscale VPN (encrypted)
+    |
+NAS / Remote Host
+    |-- Docker: intervals-icu-mcp (Streamable HTTP on port 8765)
+    |-- Tailscale Serve/Funnel (HTTPS termination)
+    |
+    v
+intervals.icu API (HTTPS)
+```
+
+## Prerequisites
+
+- Docker host (NAS, VPS, home server, etc.)
+- Docker and Docker Compose
+- Your Intervals.icu API key and athlete ID
+- Tailscale account (free at https://tailscale.com)
+
+## Setup
+
+### 1. Clone and configure
+
+```bash
+git clone https://github.com/eddmann/intervals-icu-mcp.git
+cd intervals-icu-mcp
+```
+
+Create a `.env` file with your credentials (see `.env.example`):
+
+```bash
+INTERVALS_ICU_API_KEY=your_api_key_here
+INTERVALS_ICU_ATHLETE_ID=your_athlete_id_here
+```
+
+### 2. Build and start
+
+```bash
+docker compose up -d --build
+```
+
+Verify it's running:
+
+```bash
+curl -X POST http://localhost:8765/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}},"id":1}'
+```
+
+### 3. Expose via Tailscale
+
+Install Tailscale on your Docker host and authenticate.
+
+**For access from your own devices only (Tailscale Serve):**
+
+```bash
+tailscale serve --bg --https=8443 http://localhost:8765
+```
+
+**For access from cloud services like claude.ai (Tailscale Funnel):**
+
+```bash
+tailscale funnel --bg --https=443 http://localhost:8765
+```
+
+Funnel exposes the server to the public internet via Tailscale's HTTPS proxy. This is required for services like claude.ai whose servers are not on your Tailnet.
+
+### 4. Connect Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "intervals-icu": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://YOUR-HOST.YOUR-TAILNET.ts.net/mcp"
+      ]
+    }
+  }
+}
+```
+
+Replace the URL with your Tailscale hostname (find it with `tailscale status`).
+
+## Transport
+
+The server uses Streamable HTTP transport when deployed via Docker (configured via `MCP_TRANSPORT=streamable-http` in `docker-compose.yml`). The default stdio transport is used when running locally.
+
+## Synology NAS Notes
+
+- The DS224+ (Intel J4125) and similar x86_64 NAS models work out of the box
+- Use Container Manager's Project feature to manage the docker-compose deployment
+- Install Tailscale from Package Center
+- Use Task Scheduler to run `tailscale serve` or `tailscale funnel` at boot (user: root)
+- The Dockerfile removes `--platform=$TARGETPLATFORM` for compatibility with Synology's Docker version
+
+## Maintenance
+
+```bash
+# Update
+git pull
+docker compose up -d --build
+
+# View logs
+docker compose logs -f
+
+# Restart
+docker compose restart
+
+# Stop
+docker compose down
+```

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -722,7 +722,15 @@ class ICUClient:
             params["types"] = ",".join(streams)
 
         response = await self._request("GET", f"/activity/{activity_id}/streams", params=params)
-        return ActivityStreams(**response.json())
+        # API returns a list of stream objects: [{type, name, data, ...}, ...]
+        # Convert to a dict keyed by stream type for the ActivityStreams model
+        streams_dict: dict[str, Any] = {}
+        for stream_obj in response.json():
+            stream_type = stream_obj.get("type")
+            stream_data = stream_obj.get("data")
+            if stream_type and stream_data is not None:
+                streams_dict[stream_type] = stream_data
+        return ActivityStreams(**streams_dict)
 
     async def get_best_efforts(
         self,

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -569,6 +569,7 @@ class ICUClient:
         athlete_id: str | None = None,
         oldest: str | None = None,
         newest: str | None = None,
+        sport_type: str = "Ride",
     ) -> PowerCurve:
         """Get power curve data (best efforts for various durations).
 
@@ -576,20 +577,33 @@ class ICUClient:
             athlete_id: Athlete ID (uses config default if not provided)
             oldest: Oldest date to include (ISO-8601 format)
             newest: Newest date to include (ISO-8601 format)
+            sport_type: Sport type (e.g. "Ride", "Run", "Swim"). Required by API.
 
         Returns:
             PowerCurve with best efforts data
         """
+        from datetime import date as _date
+
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {}
 
+        # API uses a 'curves' param: e.g. "1y", "42d", "r.2025-01-01.2025-12-31"
         if oldest:
-            params["oldest"] = oldest
-        if newest:
-            params["newest"] = newest
+            end = newest or _date.today().isoformat()
+            curves = f"r.{oldest}.{end}"
+        else:
+            curves = "1y"
 
-        response = await self._request("GET", f"/athlete/{athlete_id}/power-curves", params=params)
-        return PowerCurve(**response.json())
+        params: dict[str, str] = {"type": sport_type, "curves": curves}
+
+        # Endpoint requires .json extension; returns DataCurveSetPowerCurve
+        response = await self._request(
+            "GET", f"/athlete/{athlete_id}/power-curves.json", params=params
+        )
+        data = response.json()
+        curves_list = data.get("list", [])
+        if not curves_list:
+            return PowerCurve()
+        return PowerCurve(**curves_list[0])
 
     async def get_hr_curves(
         self,

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -12,6 +12,7 @@ from .models import (
     ActivityStreams,
     ActivitySummary,
     Athlete,
+    AthleteTrainingPlan,
     BestEffort,
     Event,
     Folder,
@@ -22,6 +23,7 @@ from .models import (
     Interval,
     PaceCurve,
     PowerCurve,
+    SharedWith,
     SportSettings,
     Wellness,
     Workout,
@@ -1151,3 +1153,441 @@ class ICUClient:
             json={"start_date_local": new_date},
         )
         return Event(**response.json())
+
+    # ==================== Workout CRUD Endpoints ====================
+
+    async def get_workouts(
+        self,
+        athlete_id: str | None = None,
+    ) -> list[Workout]:
+        """List all workouts in the athlete's library.
+
+        Args:
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            List of Workout objects
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("GET", f"/athlete/{athlete_id}/workouts")
+        adapter = TypeAdapter(list[Workout])
+        return adapter.validate_python(response.json())
+
+    async def get_workout(
+        self,
+        workout_id: int,
+        athlete_id: str | None = None,
+    ) -> Workout:
+        """Get a single workout by ID.
+
+        Args:
+            workout_id: Workout ID
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Workout object
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("GET", f"/athlete/{athlete_id}/workouts/{workout_id}")
+        return Workout(**response.json())
+
+    async def create_workout(
+        self,
+        workout_data: dict[str, Any],
+        athlete_id: str | None = None,
+    ) -> Workout:
+        """Create a new workout in a folder.
+
+        Args:
+            workout_data: Workout data dictionary (must include folder_id)
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Created Workout object
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("POST", f"/athlete/{athlete_id}/workouts", json=workout_data)
+        return Workout(**response.json())
+
+    async def update_workout(
+        self,
+        workout_id: int,
+        workout_data: dict[str, Any],
+        athlete_id: str | None = None,
+    ) -> Workout:
+        """Update an existing workout.
+
+        Args:
+            workout_id: Workout ID
+            workout_data: Updated workout data dictionary
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Updated Workout object
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request(
+            "PUT", f"/athlete/{athlete_id}/workouts/{workout_id}", json=workout_data
+        )
+        return Workout(**response.json())
+
+    async def delete_workout(
+        self,
+        workout_id: int,
+        delete_related: bool = False,
+        athlete_id: str | None = None,
+    ) -> bool:
+        """Delete a workout.
+
+        Args:
+            workout_id: Workout ID
+            delete_related: Also delete workouts added at the same time on a plan
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            True if deletion was successful
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        params: dict[str, Any] = {}
+        if delete_related:
+            params["others"] = "true"
+        await self._request("DELETE", f"/athlete/{athlete_id}/workouts/{workout_id}", params=params)
+        return True
+
+    async def bulk_create_workouts(
+        self,
+        workouts_data: list[dict[str, Any]],
+        athlete_id: str | None = None,
+    ) -> list[Workout]:
+        """Create multiple workouts in a single request.
+
+        Args:
+            workouts_data: List of workout data dictionaries
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            List of created Workout objects
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request(
+            "POST", f"/athlete/{athlete_id}/workouts/bulk", json=workouts_data
+        )
+        adapter = TypeAdapter(list[Workout])
+        return adapter.validate_python(response.json())
+
+    async def get_workout_tags(
+        self,
+        athlete_id: str | None = None,
+    ) -> list[str]:
+        """List all workout tags for an athlete.
+
+        Args:
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            List of tag strings
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("GET", f"/athlete/{athlete_id}/workout-tags")
+        return response.json()
+
+    async def duplicate_workouts(
+        self,
+        workout_ids: list[int],
+        num_copies: int = 1,
+        weeks_between: int = 1,
+        athlete_id: str | None = None,
+    ) -> list[Workout]:
+        """Duplicate workouts on a plan.
+
+        Args:
+            workout_ids: List of workout IDs to duplicate
+            num_copies: Number of copies to create
+            weeks_between: Weeks between each copy
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            List of created Workout objects
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        payload = {
+            "workoutIds": workout_ids,
+            "numCopies": num_copies,
+            "weeksBetween": weeks_between,
+        }
+        response = await self._request(
+            "POST", f"/athlete/{athlete_id}/duplicate-workouts", json=payload
+        )
+        adapter = TypeAdapter(list[Workout])
+        return adapter.validate_python(response.json())
+
+    # ==================== Folder CRUD Endpoints ====================
+
+    async def create_folder(
+        self,
+        folder_data: dict[str, Any],
+        athlete_id: str | None = None,
+    ) -> Folder:
+        """Create a new workout folder or training plan.
+
+        Args:
+            folder_data: Folder data dictionary (must include name)
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Created Folder object
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("POST", f"/athlete/{athlete_id}/folders", json=folder_data)
+        return Folder(**response.json())
+
+    async def update_folder(
+        self,
+        folder_id: int,
+        folder_data: dict[str, Any],
+        athlete_id: str | None = None,
+    ) -> Folder:
+        """Update an existing folder or training plan.
+
+        Args:
+            folder_id: Folder ID
+            folder_data: Updated folder data dictionary
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Updated Folder object
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request(
+            "PUT", f"/athlete/{athlete_id}/folders/{folder_id}", json=folder_data
+        )
+        return Folder(**response.json())
+
+    async def delete_folder(
+        self,
+        folder_id: int,
+        athlete_id: str | None = None,
+    ) -> bool:
+        """Delete a folder and all its workouts.
+
+        Args:
+            folder_id: Folder ID
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            True if deletion was successful
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        await self._request("DELETE", f"/athlete/{athlete_id}/folders/{folder_id}")
+        return True
+
+    async def update_plan_workouts(
+        self,
+        folder_id: int,
+        workout_data: dict[str, Any],
+        oldest: str | None = None,
+        newest: str | None = None,
+        athlete_id: str | None = None,
+    ) -> list[Workout]:
+        """Batch update workouts on a plan.
+
+        Args:
+            folder_id: Folder/plan ID
+            workout_data: Fields to update on matching workouts
+            oldest: Oldest date in range (ISO-8601)
+            newest: Newest date in range (ISO-8601)
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            List of updated Workout objects
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        params: dict[str, Any] = {}
+        if oldest:
+            params["oldest"] = oldest
+        if newest:
+            params["newest"] = newest
+        response = await self._request(
+            "PUT",
+            f"/athlete/{athlete_id}/folders/{folder_id}/workouts",
+            json=workout_data,
+            params=params,
+        )
+        adapter = TypeAdapter(list[Workout])
+        return adapter.validate_python(response.json())
+
+    async def get_folder_shared_with(
+        self,
+        folder_id: int,
+        athlete_id: str | None = None,
+    ) -> list[SharedWith]:
+        """List athletes a folder is shared with.
+
+        Args:
+            folder_id: Folder ID
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            List of SharedWith objects
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request(
+            "GET", f"/athlete/{athlete_id}/folders/{folder_id}/shared-with"
+        )
+        adapter = TypeAdapter(list[SharedWith])
+        return adapter.validate_python(response.json())
+
+    async def update_folder_shared_with(
+        self,
+        folder_id: int,
+        shared_with: list[dict[str, Any]],
+        athlete_id: str | None = None,
+    ) -> list[SharedWith]:
+        """Add or remove athletes from a folder's share list.
+
+        Args:
+            folder_id: Folder ID
+            shared_with: List of dicts with athlete id and canEdit flag
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Updated list of SharedWith objects
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request(
+            "PUT",
+            f"/athlete/{athlete_id}/folders/{folder_id}/shared-with",
+            json=shared_with,
+        )
+        adapter = TypeAdapter(list[SharedWith])
+        return adapter.validate_python(response.json())
+
+    # ==================== Training Plan Endpoints ====================
+
+    async def get_training_plan(
+        self,
+        athlete_id: str | None = None,
+    ) -> AthleteTrainingPlan:
+        """Get the athlete's current training plan.
+
+        Args:
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            AthleteTrainingPlan object
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("GET", f"/athlete/{athlete_id}/training-plan")
+        return AthleteTrainingPlan(**response.json())
+
+    async def set_training_plan(
+        self,
+        plan_data: dict[str, Any],
+        athlete_id: str | None = None,
+    ) -> AthleteTrainingPlan:
+        """Set or change the athlete's training plan.
+
+        Args:
+            plan_data: Plan data (training_plan_id, training_plan_start_date, optional alias)
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Updated AthleteTrainingPlan object
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request(
+            "PUT", f"/athlete/{athlete_id}/training-plan", json=plan_data
+        )
+        return AthleteTrainingPlan(**response.json())
+
+    async def apply_plan_changes(
+        self,
+        athlete_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Apply pending training plan changes to the calendar.
+
+        Args:
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Result of applying plan changes
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("PUT", f"/athlete/{athlete_id}/apply-plan-changes")
+        return response.json()
+
+    # ==================== Workout File Import/Export Endpoints ====================
+
+    async def import_workout(
+        self,
+        folder_id: int,
+        file_content: bytes,
+        filename: str,
+        activity_type: str | None = None,
+        athlete_id: str | None = None,
+    ) -> Workout:
+        """Import a workout file (.zwo, .mrc, .erg, or .fit) into a folder.
+
+        Args:
+            folder_id: Folder ID to import into
+            file_content: Raw file bytes
+            filename: Original filename with extension
+            activity_type: Activity type (e.g., Ride, Run)
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            Imported Workout object
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        params: dict[str, Any] = {}
+        if activity_type:
+            params["type"] = activity_type
+        files = {"file": (filename, file_content)}
+        response = await self._request(
+            "POST",
+            f"/athlete/{athlete_id}/folders/{folder_id}/import-workout",
+            files=files,
+            params=params,
+        )
+        return Workout(**response.json())
+
+    async def download_workout(
+        self,
+        workout_data: dict[str, Any],
+        ext: str,
+        athlete_id: str | None = None,
+    ) -> bytes:
+        """Convert a workout to a file format (.zwo, .mrc, .erg, or .fit).
+
+        Args:
+            workout_data: Workout data to convert
+            ext: File extension (zwo, mrc, erg, or fit)
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            File content as bytes
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        ext_with_dot = f".{ext.lstrip('.')}"
+        response = await self._request(
+            "POST",
+            f"/athlete/{athlete_id}/download-workout{ext_with_dot}",
+            json=workout_data,
+        )
+        return response.content
+
+    async def download_workouts_zip(
+        self,
+        athlete_id: str | None = None,
+    ) -> bytes:
+        """Download all workouts as a ZIP archive.
+
+        Args:
+            athlete_id: Athlete ID (uses config default if not provided)
+
+        Returns:
+            ZIP file content as bytes
+        """
+        athlete_id = athlete_id or self.config.intervals_icu_athlete_id
+        response = await self._request("GET", f"/athlete/{athlete_id}/workouts.zip")
+        return response.content

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -569,6 +569,7 @@ class ICUClient:
         athlete_id: str | None = None,
         oldest: str | None = None,
         newest: str | None = None,
+        sport_type: str | None = None,
     ) -> PowerCurve:
         """Get power curve data (best efforts for various durations).
 
@@ -576,6 +577,7 @@ class ICUClient:
             athlete_id: Athlete ID (uses config default if not provided)
             oldest: Oldest date to include (ISO-8601 format)
             newest: Newest date to include (ISO-8601 format)
+            sport_type: Activity type (e.g., 'Ride', 'Run', 'Swim')
 
         Returns:
             PowerCurve with best efforts data
@@ -587,6 +589,8 @@ class ICUClient:
             params["oldest"] = oldest
         if newest:
             params["newest"] = newest
+        if sport_type:
+            params["type"] = sport_type
 
         response = await self._request("GET", f"/athlete/{athlete_id}/power-curves", params=params)
         return PowerCurve(**response.json())

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -722,7 +722,10 @@ class ICUClient:
             params["types"] = ",".join(streams)
 
         response = await self._request("GET", f"/activity/{activity_id}/streams", params=params)
-        return ActivityStreams(**response.json())
+        data = response.json()
+        if isinstance(data, list):
+            data = {item["type"]: item["data"] for item in data if "type" in item and "data" in item}
+        return ActivityStreams(**data)
 
     async def get_best_efforts(
         self,

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -419,9 +419,17 @@ class Interval(BaseModel):
 
 
 class ActivityStreams(BaseModel):
-    """Time-series data streams for an activity."""
+    """Time-series data streams for an activity.
+
+    Note: when fetching all streams (no type filter), the API returns fixed_watts
+    renamed to 'raw_watts'. When specific types are requested including 'watts',
+    fixed_watts is returned as 'watts'.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     watts: list[int | None] | None = None
+    raw_watts: list[int | None] | None = None  # returned when types=null
     heartrate: list[int | None] | None = None
     cadence: list[int | None] | None = None
     velocity_smooth: list[float | None] | None = None

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -7,7 +7,22 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # Type aliases for common enums
 ActivityType = Literal["Ride", "Run", "Swim", "Walk", "Hike", "VirtualRide", "VirtualRun", "Other"]
-EventCategory = Literal["WORKOUT", "NOTE", "RACE", "GOAL"]
+EventCategory = Literal[
+    "WORKOUT",
+    "RACE_A",
+    "RACE_B",
+    "RACE_C",
+    "NOTE",
+    "PLAN",
+    "HOLIDAY",
+    "SICK",
+    "INJURED",
+    "SET_EFTP",
+    "FITNESS_DAYS",
+    "SEASON_START",
+    "TARGET",
+    "SET_FITNESS",
+]
 
 
 # ==================== Athlete Models ====================
@@ -170,7 +185,7 @@ class Event(BaseModel):
 
     id: int
     start_date_local: str  # ISO-8601 date
-    category: str | None = None  # WORKOUT, NOTE, RACE, GOAL
+    category: str | None = None
     name: str | None = None
     description: str | None = None
     type: str | None = None
@@ -188,6 +203,17 @@ class Event(BaseModel):
     athlete_cannot_edit: bool | None = Field(None, alias="athlete_cannot_edit")
     external_id: str | None = Field(None, alias="external_id")
     created_by_id: str | None = Field(None, alias="created_by_id")
+    workout_doc: dict[str, Any] | None = None
+    indoor: bool | None = None
+    target: str | None = None  # AUTO, POWER, HR, PACE
+    tags: list[str] = Field(default_factory=list)
+    sub_type: str | None = None  # NONE, COMMUTE, WARMUP, COOLDOWN, RACE
+    load_target: int | None = None
+    time_target: int | None = None
+    for_week: bool | None = None
+    carbs_per_hour: int | None = None
+    plan_folder_id: int | None = None
+    plan_workout_id: int | None = None
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -212,6 +238,18 @@ class Workout(BaseModel):
     indoor: bool | None = None
     color: str | None = None
     type: str | None = None
+    workout_doc: dict[str, Any] | None = None
+    day: int | None = None
+    days: int | None = None
+    target: str | None = None  # AUTO, POWER, HR, PACE
+    targets: list[dict[str, Any]] | None = None
+    tags: list[str] = Field(default_factory=list)
+    sub_type: str | None = None
+    for_week: bool | None = None
+    hide_from_athlete: bool | None = None
+    carbs_per_hour: int | None = None
+    time: str | None = None
+    updated: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -228,6 +266,16 @@ class Folder(BaseModel):
     duration_weeks: int | None = Field(None, alias="duration_weeks")
     hours_per_week_min: int | None = Field(None, alias="hours_per_week_min")
     hours_per_week_max: int | None = Field(None, alias="hours_per_week_max")
+    type: str | None = None  # FOLDER or PLAN
+    visibility: str | None = None  # PRIVATE or PUBLIC
+    rollout_weeks: int | None = None
+    auto_rollout_day: int | None = None
+    read_only_workouts: bool | None = None
+    starting_ctl: int | None = None
+    starting_atl: int | None = None
+    activity_types: list[str] = Field(default_factory=list)
+    workout_targets: list[str] = Field(default_factory=list)
+    blurb: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -288,12 +336,24 @@ class PaceCurve(BaseModel):
 class AthleteTrainingPlan(BaseModel):
     """Athlete's current training plan."""
 
-    athlete_id: str | None = Field(None, alias="athlete_id")
-    folder_id: int | None = Field(None, alias="folder_id")
-    plan_name: str | None = Field(None, alias="plan_name")
-    start_date_local: str | None = Field(None, alias="start_date_local")
-    end_date_local: str | None = Field(None, alias="end_date_local")
-    weeks_remaining: int | None = Field(None, alias="weeks_remaining")
+    id: str | None = None
+    training_plan_id: int | None = None
+    training_plan_start_date: str | None = None
+    training_plan_alias: str | None = None
+    training_plan_last_applied: str | None = None
+    timezone: str | None = None
+    training_plan: "Folder | None" = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SharedWith(BaseModel):
+    """Athlete a folder is shared with."""
+
+    id: str
+    name: str | None = None
+    can_edit: bool | None = Field(None, alias="canEdit")
+    email: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 # Type aliases for common enums
 ActivityType = Literal["Ride", "Run", "Swim", "Walk", "Hike", "VirtualRide", "VirtualRun", "Other"]
@@ -217,6 +217,11 @@ class Event(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
+    @field_validator("tags", mode="before")
+    @classmethod
+    def coerce_tags(cls, v: Any) -> list[str]:
+        return v if v is not None else []
+
 
 # ==================== Workout Library Models ====================
 
@@ -252,6 +257,11 @@ class Workout(BaseModel):
     updated: str | None = None
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def coerce_tags(cls, v: Any) -> list[str]:
+        return v if v is not None else []
 
 
 class Folder(BaseModel):

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -38,7 +38,7 @@ class Athlete(BaseModel):
     atl: float | None = None
     tsb: float | None = None
     ramp_rate: float | None = None
-    sport_settings: list[SportSettings] = Field(default_factory=list[SportSettings])
+    sport_settings: list[SportSettings] = Field(default_factory=list)
 
 
 class AthleteProfile(BaseModel):
@@ -247,12 +247,21 @@ class DataCurvePt(BaseModel):
 
 
 class PowerCurve(BaseModel):
-    """Power curve data for an athlete."""
+    """Power curve data (DataCurve) from the Intervals.icu API.
 
-    name: str | None = None
-    type: str | None = None
-    athlete_id: str | None = None
-    data: list[DataCurvePt] = Field(default_factory=list[DataCurvePt])
+    secs[i] and values[i] are parallel arrays — values[i] is the peak watts
+    at duration secs[i]. activity_id[i] is the activity where that effort occurred.
+    """
+
+    id: str | None = None
+    label: str | None = None
+    start_date_local: str | None = None
+    end_date_local: str | None = None
+    secs: list[int] = Field(default_factory=list)
+    values: list[int] = Field(default_factory=list)
+    activity_id: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(populate_by_name=True)
 
 
 class HRCurve(BaseModel):
@@ -261,7 +270,7 @@ class HRCurve(BaseModel):
     name: str | None = None
     type: str | None = None
     athlete_id: str | None = None
-    data: list[DataCurvePt] = Field(default_factory=list[DataCurvePt])
+    data: list[DataCurvePt] = Field(default_factory=list)
 
 
 class PaceCurve(BaseModel):
@@ -270,7 +279,7 @@ class PaceCurve(BaseModel):
     name: str | None = None
     type: str | None = None
     athlete_id: str | None = None
-    data: list[DataCurvePt] = Field(default_factory=list[DataCurvePt])
+    data: list[DataCurvePt] = Field(default_factory=list)
 
 
 # ==================== Training Plan Models ====================
@@ -406,7 +415,7 @@ class Gear(BaseModel):
     distance: float | None = None  # Total distance in meters
     moving_time: int | None = Field(None, alias="moving_time")  # Total time in seconds
     activity_count: int | None = Field(None, alias="activity_count")
-    reminders: list[GearReminder] = Field(default_factory=list[GearReminder])
+    reminders: list[GearReminder] = Field(default_factory=list)
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -426,6 +435,6 @@ class HistogramBin(BaseModel):
 class Histogram(BaseModel):
     """Histogram data for activity metrics."""
 
-    bins: list[HistogramBin] = Field(default_factory=list[HistogramBin])
+    bins: list[HistogramBin] = Field(default_factory=list)
     total_count: int | None = None
     total_secs: int | None = None

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -27,17 +27,22 @@ class SportSettings(BaseModel):
 class Athlete(BaseModel):
     """Full athlete profile information."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     id: str
     name: str
     email: str | None = None
-    weight: float | None = None
-    dob: str | None = None
+    weight: float | None = Field(None, alias="icu_weight")
+    dob: str | None = Field(None, alias="icu_date_of_birth")
     sex: str | None = None
+    city: str | None = None
+    country: str | None = None
     created: datetime | None = None
     ctl: float | None = None
     atl: float | None = None
     tsb: float | None = None
     ramp_rate: float | None = None
+    icu_resting_hr: int | None = None
     sport_settings: list[SportSettings] = Field(default_factory=list[SportSettings])
 
 

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -50,6 +50,14 @@ from .tools.event_management import (
     update_event,
 )
 from .tools.events import get_calendar_events, get_event, get_upcoming_workouts
+from .tools.folder_management import (
+    create_folder,
+    delete_folder,
+    get_folder_sharing,
+    update_folder,
+    update_folder_sharing,
+    update_plan_workouts,
+)
 from .tools.gear import (
     create_gear,
     create_gear_reminder,
@@ -66,8 +74,22 @@ from .tools.sport_settings import (
     get_sport_settings,
     update_sport_settings,
 )
+from .tools.training_plan import apply_plan_changes, get_training_plan, set_training_plan
 from .tools.wellness import get_wellness_data, get_wellness_for_date, update_wellness
-from .tools.workout_library import get_workout_library, get_workouts_in_folder
+from .tools.workout_library import (
+    bulk_create_workouts,
+    create_workout,
+    delete_workout,
+    download_all_workouts,
+    duplicate_workouts,
+    export_workout,
+    get_workout,
+    get_workout_library,
+    get_workout_tags,
+    get_workouts_in_folder,
+    import_workout,
+    update_workout,
+)
 
 # Register activity tools
 mcp.tool()(get_recent_activities)
@@ -119,6 +141,29 @@ mcp.tool()(get_pace_curves)
 # Register workout library tools
 mcp.tool()(get_workout_library)
 mcp.tool()(get_workouts_in_folder)
+mcp.tool()(get_workout)
+mcp.tool()(create_workout)
+mcp.tool()(update_workout)
+mcp.tool()(delete_workout)
+mcp.tool()(bulk_create_workouts)
+mcp.tool()(get_workout_tags)
+mcp.tool()(duplicate_workouts)
+mcp.tool()(import_workout)
+mcp.tool()(export_workout)
+mcp.tool()(download_all_workouts)
+
+# Register folder management tools
+mcp.tool()(create_folder)
+mcp.tool()(update_folder)
+mcp.tool()(delete_folder)
+mcp.tool()(update_plan_workouts)
+mcp.tool()(get_folder_sharing)
+mcp.tool()(update_folder_sharing)
+
+# Register training plan tools
+mcp.tool()(get_training_plan)
+mcp.tool()(set_training_plan)
+mcp.tool()(apply_plan_changes)
 
 # Register gear management tools
 mcp.tool()(get_gear_list)

--- a/src/intervals_icu_mcp/server.py
+++ b/src/intervals_icu_mcp/server.py
@@ -332,8 +332,10 @@ Then offer to create the events in my calendar if I approve the plan."""
 
 def main():
     """Main entry point for the Intervals.icu MCP server."""
-    # Run the server with stdio transport (default)
-    mcp.run()
+    import os
+
+    transport = os.environ.get("MCP_TRANSPORT", "stdio")
+    mcp.run(transport=transport)
 
 
 if __name__ == "__main__":

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -13,6 +13,8 @@ from ..response_builder import ResponseBuilder
 async def get_recent_activities(
     limit: Annotated[int, "Number of activities to fetch"] = 30,
     days_back: Annotated[int, "Number of days to look back"] = 30,
+    oldest: Annotated[str | None, "Oldest date to fetch (YYYY-MM-DD), overrides days_back"] = None,
+    newest: Annotated[str | None, "Newest date to fetch (YYYY-MM-DD), defaults to today"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Get recent activities for the authenticated athlete.
@@ -21,8 +23,10 @@ async def get_recent_activities(
     duration, power, heart rate, and training load.
 
     Args:
-        limit: Number of activities to fetch (default 30, max 100)
-        days_back: Number of days to look back (default 30)
+        limit: Number of activities to fetch (default 30, max 500)
+        days_back: Number of days to look back (default 30, ignored if oldest is provided)
+        oldest: Explicit oldest date (YYYY-MM-DD). Overrides days_back.
+        newest: Explicit newest date (YYYY-MM-DD). Defaults to today.
 
     Returns:
         JSON string with activity summaries
@@ -32,13 +36,15 @@ async def get_recent_activities(
 
     try:
         # Calculate date range
-        oldest_date = datetime.now() - timedelta(days=days_back)
-        oldest = oldest_date.strftime("%Y-%m-%d")
+        if oldest is None:
+            oldest_date = datetime.now() - timedelta(days=days_back)
+            oldest = oldest_date.strftime("%Y-%m-%d")
 
         async with ICUClient(config) as client:
             activities = await client.get_activities(
                 oldest=oldest,
-                limit=min(limit, 100),  # Cap at 100
+                newest=newest,
+                limit=min(limit, 500),  # Cap at 500
             )
 
             if not activities:

--- a/src/intervals_icu_mcp/tools/activity_analysis.py
+++ b/src/intervals_icu_mcp/tools/activity_analysis.py
@@ -56,6 +56,7 @@ async def get_activity_streams(
 
             for stream_name in [
                 "watts",
+                "raw_watts",
                 "heartrate",
                 "cadence",
                 "velocity_smooth",

--- a/src/intervals_icu_mcp/tools/athlete.py
+++ b/src/intervals_icu_mcp/tools/athlete.py
@@ -25,6 +25,8 @@ async def get_athlete_profile(
 
     try:
         async with ICUClient(config) as client:
+            from datetime import date, timedelta
+
             athlete = await client.get_athlete()
 
             # Build profile data
@@ -42,16 +44,25 @@ async def get_athlete_profile(
             if athlete.weight:
                 profile["weight_kg"] = athlete.weight
 
-            # Fitness metrics
+            # Fitness metrics come from wellness records, not the athlete endpoint
             fitness: dict[str, Any] = {}
-            if athlete.ctl is not None:
-                fitness["ctl"] = round(athlete.ctl, 1)
-            if athlete.atl is not None:
-                fitness["atl"] = round(athlete.atl, 1)
-            if athlete.tsb is not None:
-                fitness["tsb"] = round(athlete.tsb, 1)
-            if athlete.ramp_rate is not None:
-                fitness["ramp_rate"] = round(athlete.ramp_rate, 1)
+            today = date.today()
+            oldest = (today - timedelta(days=7)).isoformat()
+            wellness_records = await client.get_wellness(oldest=oldest, newest=today.isoformat())
+            wellness = None
+            for record in reversed(wellness_records):
+                if record.ctl is not None or record.atl is not None:
+                    wellness = record
+                    break
+            if wellness is not None:
+                if wellness.ctl is not None:
+                    fitness["ctl"] = round(wellness.ctl, 1)
+                if wellness.atl is not None:
+                    fitness["atl"] = round(wellness.atl, 1)
+                if wellness.tsb is not None:
+                    fitness["tsb"] = round(wellness.tsb, 1)
+                if wellness.ramp_rate is not None:
+                    fitness["ramp_rate"] = round(wellness.ramp_rate, 1)
 
             # Sport settings
             sports: list[dict[str, Any]] = []
@@ -80,40 +91,43 @@ async def get_athlete_profile(
             if sports:
                 data["sports"] = sports
 
-            # Analysis
+            # Analysis (uses wellness-sourced fitness data)
             analysis: dict[str, Any] = {}
-            if athlete.tsb is not None:
-                if athlete.tsb > 20:
+            tsb = wellness.tsb if wellness is not None else None
+            ramp_rate = wellness.ramp_rate if wellness is not None else None
+
+            if tsb is not None:
+                if tsb > 20:
                     analysis["form_status"] = "very_fresh"
                     analysis["form_description"] = "Very fresh - good for racing"
-                elif athlete.tsb > 5:
+                elif tsb > 5:
                     analysis["form_status"] = "recovered"
                     analysis["form_description"] = "Recovered and ready for hard training"
-                elif athlete.tsb > -10:
+                elif tsb > -10:
                     analysis["form_status"] = "optimal"
                     analysis["form_description"] = "Optimal zone - productive training possible"
-                elif athlete.tsb > -30:
+                elif tsb > -30:
                     analysis["form_status"] = "fatigued"
                     analysis["form_description"] = "Accumulating fatigue - recovery may be needed"
                 else:
                     analysis["form_status"] = "very_fatigued"
                     analysis["form_description"] = "High fatigue - prioritize recovery"
 
-            if athlete.ramp_rate is not None:
-                if athlete.ramp_rate > 8:
+            if ramp_rate is not None:
+                if ramp_rate > 8:
                     analysis["ramp_rate_status"] = "high_risk"
                     analysis["ramp_rate_warning"] = (
                         "Fitness increasing too fast - reduce training load"
                     )
-                elif athlete.ramp_rate > 5:
+                elif ramp_rate > 5:
                     analysis["ramp_rate_status"] = "caution"
                     analysis["ramp_rate_warning"] = (
                         "Fitness increasing rapidly - monitor fatigue closely"
                     )
-                elif athlete.ramp_rate > 0:
+                elif ramp_rate > 0:
                     analysis["ramp_rate_status"] = "good"
                     analysis["ramp_rate_description"] = "Sustainable fitness gain"
-                elif athlete.ramp_rate > -5:
+                elif ramp_rate > -5:
                     analysis["ramp_rate_status"] = "declining"
                     analysis["ramp_rate_description"] = (
                         "Fitness slightly declining (taper/recovery)"
@@ -162,37 +176,61 @@ async def get_fitness_summary(
 
     try:
         async with ICUClient(config) as client:
+            from datetime import date, timedelta
+
+            # CTL/ATL/TSB are stored in wellness records, not the athlete profile.
+            # Fetch the last 7 days and use the most recent entry that has CTL data.
+            today = date.today()
+            oldest = (today - timedelta(days=7)).isoformat()
+            newest = today.isoformat()
+
+            wellness_records = await client.get_wellness(oldest=oldest, newest=newest)
+
+            # Find the most recent record with CTL populated
+            wellness = None
+            for record in reversed(wellness_records):
+                if record.ctl is not None or record.atl is not None:
+                    wellness = record
+                    break
+
             athlete = await client.get_athlete()
 
-            if athlete.ctl is None and athlete.atl is None:
+            if wellness is None:
                 return ResponseBuilder.build_error_response(
-                    "No fitness data available. Complete some activities to build your fitness history.",
+                    "No CTL/ATL/TSB fitness data available.",
                     error_type="no_data",
+                    suggestions=[
+                        "Intervals.icu calculates CTL/ATL/TSB from Training Load (TSS/hrTSS). "
+                        "Make sure your activities have a power meter or heart rate data.",
+                        "Go to Intervals.icu Settings → Training Load and verify your sport is "
+                        "configured with FTP, FTHR, or pace thresholds.",
+                        "It can take a few weeks of data before meaningful fitness metrics appear.",
+                    ],
                 )
 
             # Core metrics
             fitness: dict[str, Any] = {}
-            if athlete.ctl is not None:
+            if wellness.ctl is not None:
                 fitness["ctl"] = {
-                    "value": round(athlete.ctl, 1),
+                    "value": round(wellness.ctl, 1),
                     "description": "Chronic Training Load (Fitness)",
                     "explanation": "Long-term training load (42-day weighted average)",
                 }
-            if athlete.atl is not None:
+            if wellness.atl is not None:
                 fitness["atl"] = {
-                    "value": round(athlete.atl, 1),
+                    "value": round(wellness.atl, 1),
                     "description": "Acute Training Load (Fatigue)",
                     "explanation": "Short-term training load (7-day weighted average)",
                 }
-            if athlete.tsb is not None:
+            if wellness.tsb is not None:
                 fitness["tsb"] = {
-                    "value": round(athlete.tsb, 1),
+                    "value": round(wellness.tsb, 1),
                     "description": "Training Stress Balance (Form)",
                     "explanation": "Fitness - Fatigue",
                 }
-            if athlete.ramp_rate is not None:
+            if wellness.ramp_rate is not None:
                 fitness["ramp_rate"] = {
-                    "value": round(athlete.ramp_rate, 1),
+                    "value": round(wellness.ramp_rate, 1),
                     "description": "Rate of fitness change (CTL increase per week)",
                 }
 
@@ -200,17 +238,17 @@ async def get_fitness_summary(
             analysis: dict[str, Any] = {}
 
             # TSB interpretation
-            if athlete.tsb is not None:
-                if athlete.tsb > 20:
+            if wellness.tsb is not None:
+                if wellness.tsb > 20:
                     analysis["form_status"] = "very_fresh"
                     analysis["form_interpretation"] = "You're very fresh - good for racing!"
-                elif athlete.tsb > 5:
+                elif wellness.tsb > 5:
                     analysis["form_status"] = "recovered"
                     analysis["form_interpretation"] = "You're recovered and ready for hard training"
-                elif athlete.tsb > -10:
+                elif wellness.tsb > -10:
                     analysis["form_status"] = "optimal"
                     analysis["form_interpretation"] = "Optimal zone - productive training possible"
-                elif athlete.tsb > -30:
+                elif wellness.tsb > -30:
                     analysis["form_status"] = "fatigued"
                     analysis["form_interpretation"] = (
                         "You're accumulating fatigue - recovery may be needed"
@@ -220,19 +258,19 @@ async def get_fitness_summary(
                     analysis["form_interpretation"] = "High fatigue - prioritize recovery"
 
             # Ramp rate interpretation
-            if athlete.ramp_rate is not None:
-                if athlete.ramp_rate > 8:
+            if wellness.ramp_rate is not None:
+                if wellness.ramp_rate > 8:
                     analysis["ramp_rate_status"] = "high_risk"
                     analysis["ramp_rate_interpretation"] = "Fitness increasing too fast"
                     analysis["ramp_rate_warning"] = "Reduce training load to avoid overtraining"
-                elif athlete.ramp_rate > 5:
+                elif wellness.ramp_rate > 5:
                     analysis["ramp_rate_status"] = "caution"
                     analysis["ramp_rate_interpretation"] = "Fitness increasing rapidly"
                     analysis["ramp_rate_warning"] = "Monitor fatigue and recovery closely"
-                elif athlete.ramp_rate > 0:
+                elif wellness.ramp_rate > 0:
                     analysis["ramp_rate_status"] = "good"
                     analysis["ramp_rate_interpretation"] = "Sustainable fitness gain"
-                elif athlete.ramp_rate > -5:
+                elif wellness.ramp_rate > -5:
                     analysis["ramp_rate_status"] = "declining"
                     analysis["ramp_rate_interpretation"] = (
                         "Fitness slightly declining (taper/recovery)"
@@ -243,15 +281,15 @@ async def get_fitness_summary(
 
             # Training recommendations
             recommendations: list[str] = []
-            if athlete.tsb is not None and athlete.ramp_rate is not None:
-                if athlete.tsb < -30:
+            if wellness.tsb is not None and wellness.ramp_rate is not None:
+                if wellness.tsb < -30:
                     recommendations.append("Take an easy week or rest days")
                     recommendations.append("Focus on recovery and low-intensity activities")
-                elif athlete.tsb < -10 and athlete.ramp_rate > 5:
+                elif wellness.tsb < -10 and wellness.ramp_rate > 5:
                     recommendations.append("Balance hard training with recovery")
                     recommendations.append("Consider a recovery week soon")
-                elif athlete.tsb > 5:
-                    if athlete.ramp_rate < 0:
+                elif wellness.tsb > 5:
+                    if wellness.ramp_rate < 0:
                         recommendations.append("Good time to increase training load")
                         recommendations.append("Consider adding volume or intensity")
                     else:
@@ -266,6 +304,7 @@ async def get_fitness_summary(
 
             data = {
                 "athlete_name": athlete.name,
+                "as_of_date": wellness.id,
                 "fitness_metrics": fitness,
             }
 

--- a/src/intervals_icu_mcp/tools/athlete.py
+++ b/src/intervals_icu_mcp/tools/athlete.py
@@ -41,6 +41,12 @@ async def get_athlete_profile(
                 profile["dob"] = athlete.dob
             if athlete.weight:
                 profile["weight_kg"] = athlete.weight
+            if athlete.city:
+                profile["city"] = athlete.city
+            if athlete.country:
+                profile["country"] = athlete.country
+            if athlete.icu_resting_hr:
+                profile["resting_hr"] = athlete.icu_resting_hr
 
             # Fitness metrics
             fitness: dict[str, Any] = {}

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -98,7 +98,10 @@ async def create_event(
         "text syntax instead to create structured workouts.",
     ] = None,
     tags: Annotated[
-        str | None, "Comma-separated tags (e.g., 'intervals,threshold,tuesday')"
+        str | None,
+        "Comma-separated tags (e.g., 'intervals,threshold'). "
+        "NOTE: Do NOT add tags unless the user explicitly requests them. "
+        "Tags render as visible hashtags on the event name in the UI, which is distracting.",
     ] = None,
     indoor: Annotated[bool | None, "Whether this is an indoor workout"] = None,
     target: Annotated[str | None, "Target metric: AUTO, POWER, HR, or PACE"] = None,

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -1,5 +1,6 @@
 """Event/calendar management tools for Intervals.icu MCP server."""
 
+import json
 from datetime import datetime
 from typing import Annotated, Any
 
@@ -7,34 +8,99 @@ from fastmcp import Context
 
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
+from ..models import Event
 from ..response_builder import ResponseBuilder
+
+VALID_CATEGORIES = [
+    "WORKOUT",
+    "RACE_A",
+    "RACE_B",
+    "RACE_C",
+    "NOTE",
+    "PLAN",
+    "HOLIDAY",
+    "SICK",
+    "INJURED",
+    "SET_EFTP",
+    "FITNESS_DAYS",
+    "SEASON_START",
+    "TARGET",
+    "SET_FITNESS",
+]
+
+VALID_TARGETS = ["AUTO", "POWER", "HR", "PACE"]
+VALID_SUB_TYPES = ["NONE", "COMMUTE", "WARMUP", "COOLDOWN", "RACE"]
+
+
+def _event_to_dict(event: Event) -> dict[str, Any]:
+    """Build a response dict from an Event model, including all populated fields."""
+    result: dict[str, Any] = {
+        "id": event.id,
+        "start_date": event.start_date_local,
+        "name": event.name,
+        "category": event.category,
+    }
+    if event.description:
+        result["description"] = event.description
+    if event.type:
+        result["type"] = event.type
+    if event.moving_time:
+        result["duration_seconds"] = event.moving_time
+    if event.distance:
+        result["distance_meters"] = event.distance
+    if event.icu_training_load:
+        result["training_load"] = event.icu_training_load
+    if event.color:
+        result["color"] = event.color
+    if event.indoor is not None:
+        result["indoor"] = event.indoor
+    if event.target:
+        result["target"] = event.target
+    if event.tags:
+        result["tags"] = event.tags
+    if event.sub_type:
+        result["sub_type"] = event.sub_type
+    if event.load_target:
+        result["load_target"] = event.load_target
+    if event.time_target:
+        result["time_target"] = event.time_target
+    if event.workout_doc:
+        result["workout_doc"] = event.workout_doc
+    return result
 
 
 async def create_event(
     start_date: Annotated[str, "Start date in YYYY-MM-DD format"],
     name: Annotated[str, "Event name"],
-    category: Annotated[str, "Event category: WORKOUT, NOTE, RACE, or GOAL"],
-    description: Annotated[str | None, "Event description (optional)"] = None,
+    category: Annotated[
+        str,
+        "Event category: WORKOUT, RACE_A, RACE_B, RACE_C, NOTE, PLAN, HOLIDAY, SICK, INJURED, "
+        "SET_EFTP, FITNESS_DAYS, SEASON_START, TARGET, or SET_FITNESS",
+    ],
+    description: Annotated[str | None, "Event description or Intervals.icu workout syntax"] = None,
     event_type: Annotated[str | None, "Activity type (e.g., Ride, Run, Swim)"] = None,
     duration_seconds: Annotated[int | None, "Planned duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Planned distance in meters"] = None,
     training_load: Annotated[int | None, "Planned training load"] = None,
+    workout_doc: Annotated[
+        str | None,
+        "JSON string of structured workout document with intervals and targets",
+    ] = None,
+    tags: Annotated[
+        str | None, "Comma-separated tags (e.g., 'intervals,threshold,tuesday')"
+    ] = None,
+    indoor: Annotated[bool | None, "Whether this is an indoor workout"] = None,
+    target: Annotated[str | None, "Target metric: AUTO, POWER, HR, or PACE"] = None,
+    sub_type: Annotated[str | None, "Sub-type: NONE, COMMUTE, WARMUP, COOLDOWN, or RACE"] = None,
+    load_target: Annotated[int | None, "Target training load"] = None,
+    time_target: Annotated[int | None, "Target time in seconds"] = None,
+    color: Annotated[str | None, "Event color hex code (e.g., '#FF5733')"] = None,
     ctx: Context | None = None,
 ) -> str:
-    """Create a new calendar event (planned workout, note, race, or goal).
+    """Create a new calendar event (planned workout, note, race, goal, etc.).
 
-    Adds an event to your Intervals.icu calendar. Events can be workouts with
-    planned metrics, notes for tracking information, races, or training goals.
-
-    Args:
-        start_date: Date in ISO-8601 format (YYYY-MM-DD)
-        name: Name of the event
-        category: Type of event - WORKOUT, NOTE, RACE, or GOAL
-        description: Optional detailed description
-        event_type: Activity type (e.g., "Ride", "Run", "Swim") for workouts
-        duration_seconds: Planned duration for workouts
-        distance_meters: Planned distance for workouts
-        training_load: Planned training load for workouts
+    Adds an event to your Intervals.icu calendar. Supports the full range of event
+    categories and optional structured workout definitions via workout_doc.
 
     Returns:
         JSON string with created event data
@@ -43,10 +109,9 @@ async def create_event(
     config: ICUConfig = ctx.get_state("config")
 
     # Validate category
-    valid_categories = ["WORKOUT", "NOTE", "RACE", "GOAL"]
-    if category.upper() not in valid_categories:
+    if category.upper() not in VALID_CATEGORIES:
         return ResponseBuilder.build_error_response(
-            f"Invalid category. Must be one of: {', '.join(valid_categories)}",
+            f"Invalid category. Must be one of: {', '.join(VALID_CATEGORIES)}",
             error_type="validation_error",
         )
 
@@ -59,48 +124,64 @@ async def create_event(
             error_type="validation_error",
         )
 
+    # Validate target if provided
+    if target and target.upper() not in VALID_TARGETS:
+        return ResponseBuilder.build_error_response(
+            f"Invalid target. Must be one of: {', '.join(VALID_TARGETS)}",
+            error_type="validation_error",
+        )
+
+    # Validate sub_type if provided
+    if sub_type and sub_type.upper() not in VALID_SUB_TYPES:
+        return ResponseBuilder.build_error_response(
+            f"Invalid sub_type. Must be one of: {', '.join(VALID_SUB_TYPES)}",
+            error_type="validation_error",
+        )
+
     try:
-        # Build event data
         event_data: dict[str, Any] = {
             "start_date_local": start_date,
             "name": name,
             "category": category.upper(),
         }
 
-        if description:
+        if description is not None:
             event_data["description"] = description
-        if event_type:
+        if event_type is not None:
             event_data["type"] = event_type
-        if duration_seconds:
+        if duration_seconds is not None:
             event_data["moving_time"] = duration_seconds
-        if distance_meters:
+        if distance_meters is not None:
             event_data["distance"] = distance_meters
-        if training_load:
+        if training_load is not None:
             event_data["icu_training_load"] = training_load
+        if color is not None:
+            event_data["color"] = color
+        if indoor is not None:
+            event_data["indoor"] = indoor
+        if target is not None:
+            event_data["target"] = target.upper()
+        if sub_type is not None:
+            event_data["sub_type"] = sub_type.upper()
+        if load_target is not None:
+            event_data["load_target"] = load_target
+        if time_target is not None:
+            event_data["time_target"] = time_target
+        if tags is not None:
+            event_data["tags"] = [t.strip() for t in tags.split(",") if t.strip()]
+        if workout_doc is not None:
+            try:
+                event_data["workout_doc"] = json.loads(workout_doc)
+            except json.JSONDecodeError as e:
+                return ResponseBuilder.build_error_response(
+                    f"Invalid workout_doc JSON: {str(e)}", error_type="validation_error"
+                )
 
         async with ICUClient(config) as client:
             event = await client.create_event(event_data)
 
-            event_result: dict[str, Any] = {
-                "id": event.id,
-                "start_date": event.start_date_local,
-                "name": event.name,
-                "category": event.category,
-            }
-
-            if event.description:
-                event_result["description"] = event.description
-            if event.type:
-                event_result["type"] = event.type
-            if event.moving_time:
-                event_result["duration_seconds"] = event.moving_time
-            if event.distance:
-                event_result["distance_meters"] = event.distance
-            if event.icu_training_load:
-                event_result["training_load"] = event.icu_training_load
-
             return ResponseBuilder.build_response(
-                data=event_result,
+                data=_event_to_dict(event),
                 query_type="create_event",
                 metadata={"message": f"Successfully created {category.lower()}: {name}"},
             )
@@ -116,28 +197,33 @@ async def create_event(
 async def update_event(
     event_id: Annotated[int, "Event ID to update"],
     name: Annotated[str | None, "Updated event name"] = None,
-    description: Annotated[str | None, "Updated description"] = None,
+    description: Annotated[
+        str | None, "Updated description or Intervals.icu workout syntax"
+    ] = None,
     start_date: Annotated[str | None, "Updated start date (YYYY-MM-DD)"] = None,
     event_type: Annotated[str | None, "Updated activity type"] = None,
     duration_seconds: Annotated[int | None, "Updated duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Updated distance in meters"] = None,
     training_load: Annotated[int | None, "Updated training load"] = None,
+    workout_doc: Annotated[
+        str | None,
+        "JSON string of updated structured workout document",
+    ] = None,
+    tags: Annotated[str | None, "Updated comma-separated tags"] = None,
+    indoor: Annotated[bool | None, "Whether this is an indoor workout"] = None,
+    target: Annotated[str | None, "Updated target metric: AUTO, POWER, HR, or PACE"] = None,
+    sub_type: Annotated[
+        str | None, "Updated sub-type: NONE, COMMUTE, WARMUP, COOLDOWN, or RACE"
+    ] = None,
+    load_target: Annotated[int | None, "Updated target training load"] = None,
+    time_target: Annotated[int | None, "Updated target time in seconds"] = None,
+    color: Annotated[str | None, "Updated event color hex code"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Update an existing calendar event.
 
     Modifies one or more fields of an existing event. Only provide the fields
-    you want to change - other fields will remain unchanged.
-
-    Args:
-        event_id: ID of the event to update
-        name: New name for the event
-        description: New description
-        start_date: New start date in YYYY-MM-DD format
-        event_type: New activity type
-        duration_seconds: New planned duration
-        distance_meters: New planned distance
-        training_load: New planned training load
+    you want to change — other fields will remain unchanged.
 
     Returns:
         JSON string with updated event data
@@ -155,8 +241,21 @@ async def update_event(
                 error_type="validation_error",
             )
 
+    # Validate target if provided
+    if target and target.upper() not in VALID_TARGETS:
+        return ResponseBuilder.build_error_response(
+            f"Invalid target. Must be one of: {', '.join(VALID_TARGETS)}",
+            error_type="validation_error",
+        )
+
+    # Validate sub_type if provided
+    if sub_type and sub_type.upper() not in VALID_SUB_TYPES:
+        return ResponseBuilder.build_error_response(
+            f"Invalid sub_type. Must be one of: {', '.join(VALID_SUB_TYPES)}",
+            error_type="validation_error",
+        )
+
     try:
-        # Build update data (only include provided fields)
         event_data: dict[str, Any] = {}
 
         if name is not None:
@@ -173,6 +272,27 @@ async def update_event(
             event_data["distance"] = distance_meters
         if training_load is not None:
             event_data["icu_training_load"] = training_load
+        if color is not None:
+            event_data["color"] = color
+        if indoor is not None:
+            event_data["indoor"] = indoor
+        if target is not None:
+            event_data["target"] = target.upper()
+        if sub_type is not None:
+            event_data["sub_type"] = sub_type.upper()
+        if load_target is not None:
+            event_data["load_target"] = load_target
+        if time_target is not None:
+            event_data["time_target"] = time_target
+        if tags is not None:
+            event_data["tags"] = [t.strip() for t in tags.split(",") if t.strip()]
+        if workout_doc is not None:
+            try:
+                event_data["workout_doc"] = json.loads(workout_doc)
+            except json.JSONDecodeError as e:
+                return ResponseBuilder.build_error_response(
+                    f"Invalid workout_doc JSON: {str(e)}", error_type="validation_error"
+                )
 
         if not event_data:
             return ResponseBuilder.build_error_response(
@@ -183,26 +303,8 @@ async def update_event(
         async with ICUClient(config) as client:
             event = await client.update_event(event_id, event_data)
 
-            event_result: dict[str, Any] = {
-                "id": event.id,
-                "start_date": event.start_date_local,
-                "name": event.name,
-                "category": event.category,
-            }
-
-            if event.description:
-                event_result["description"] = event.description
-            if event.type:
-                event_result["type"] = event.type
-            if event.moving_time:
-                event_result["duration_seconds"] = event.moving_time
-            if event.distance:
-                event_result["distance_meters"] = event.distance
-            if event.icu_training_load:
-                event_result["training_load"] = event.icu_training_load
-
             return ResponseBuilder.build_response(
-                data=event_result,
+                data=_event_to_dict(event),
                 query_type="update_event",
                 metadata={"message": f"Successfully updated event {event_id}"},
             )
@@ -222,9 +324,6 @@ async def delete_event(
     """Delete a calendar event.
 
     Permanently removes an event from your calendar. This action cannot be undone.
-
-    Args:
-        event_id: ID of the event to delete
 
     Returns:
         JSON string with deletion confirmation
@@ -259,28 +358,22 @@ async def delete_event(
 async def bulk_create_events(
     events: Annotated[
         str,
-        "JSON string containing array of events. Each event should have: start_date_local, name, category, and optional fields like description, type, moving_time, distance, icu_training_load",
+        "JSON array of event objects. Each must have: start_date_local, name, category. "
+        "Optional: description, type, moving_time, distance, icu_training_load, workout_doc, tags, indoor",
     ],
     ctx: Context | None = None,
 ) -> str:
     """Create multiple calendar events in a single operation.
 
-    This is more efficient than creating events one at a time. Provide a JSON array
-    of event objects, each with the same structure as create_event.
-
-    Args:
-        events: JSON array of event objects to create
+    More efficient than creating events one at a time. Provide a JSON array of event objects.
 
     Returns:
-        JSON string with created events
+        JSON string with created events and count
     """
     assert ctx is not None
     config: ICUConfig = ctx.get_state("config")
 
     try:
-        import json
-
-        # Parse the JSON string
         try:
             parsed_data = json.loads(events)
         except json.JSONDecodeError as e:
@@ -293,11 +386,9 @@ async def bulk_create_events(
                 "Events must be a JSON array", error_type="validation_error"
             )
 
-        # Type cast after validation
         events_data: list[dict[str, Any]] = parsed_data  # type: ignore[assignment]
 
         # Validate each event
-        valid_categories = ["WORKOUT", "NOTE", "RACE", "GOAL"]
         for i, event_data in enumerate(events_data):
             if "start_date_local" not in event_data:
                 return ResponseBuilder.build_error_response(
@@ -313,16 +404,14 @@ async def bulk_create_events(
                     f"Event {i}: Missing required field 'category'",
                     error_type="validation_error",
                 )
-            if event_data["category"].upper() not in valid_categories:
+            if event_data["category"].upper() not in VALID_CATEGORIES:
                 return ResponseBuilder.build_error_response(
-                    f"Event {i}: Invalid category. Must be one of: {', '.join(valid_categories)}",
+                    f"Event {i}: Invalid category. Must be one of: {', '.join(VALID_CATEGORIES)}",
                     error_type="validation_error",
                 )
 
-            # Normalize category to uppercase
             event_data["category"] = event_data["category"].upper()
 
-            # Validate date format
             try:
                 datetime.strptime(event_data["start_date_local"], "%Y-%m-%d")
             except ValueError:
@@ -334,27 +423,7 @@ async def bulk_create_events(
         async with ICUClient(config) as client:
             created_events = await client.bulk_create_events(events_data)
 
-            events_result: list[dict[str, Any]] = []
-            for event in created_events:
-                event_info: dict[str, Any] = {
-                    "id": event.id,
-                    "start_date": event.start_date_local,
-                    "name": event.name,
-                    "category": event.category,
-                }
-
-                if event.description:
-                    event_info["description"] = event.description
-                if event.type:
-                    event_info["type"] = event.type
-                if event.moving_time:
-                    event_info["duration_seconds"] = event.moving_time
-                if event.distance:
-                    event_info["distance_meters"] = event.distance
-                if event.icu_training_load:
-                    event_info["training_load"] = event.icu_training_load
-
-                events_result.append(event_info)
+            events_result = [_event_to_dict(event) for event in created_events]
 
             return ResponseBuilder.build_response(
                 data={"events": events_result},
@@ -379,11 +448,7 @@ async def bulk_delete_events(
 ) -> str:
     """Delete multiple calendar events in a single operation.
 
-    This is more efficient than deleting events one at a time. Provide a JSON array
-    of event IDs to delete.
-
-    Args:
-        event_ids: JSON array of event IDs (integers)
+    More efficient than deleting events one at a time.
 
     Returns:
         JSON string with deletion confirmation
@@ -392,9 +457,6 @@ async def bulk_delete_events(
     config: ICUConfig = ctx.get_state("config")
 
     try:
-        import json
-
-        # Parse the JSON string
         try:
             parsed_data = json.loads(event_ids)
         except json.JSONDecodeError as e:
@@ -412,7 +474,6 @@ async def bulk_delete_events(
                 "Must provide at least one event ID to delete", error_type="validation_error"
             )
 
-        # Type cast after validation
         ids_list: list[int] = parsed_data  # type: ignore[assignment]
 
         async with ICUClient(config) as client:
@@ -439,12 +500,8 @@ async def duplicate_event(
 ) -> str:
     """Duplicate an existing event to a new date.
 
-    Creates a copy of an event with all its properties (name, type, duration, etc.)
-    but with a new date. Useful for repeating workouts or events.
-
-    Args:
-        event_id: ID of the event to duplicate
-        new_date: New date in YYYY-MM-DD format
+    Creates a copy of an event with all its properties (name, type, duration, workout_doc, etc.)
+    but on a new date. Useful for repeating workouts.
 
     Returns:
         JSON string with the duplicated event
@@ -452,7 +509,6 @@ async def duplicate_event(
     assert ctx is not None
     config: ICUConfig = ctx.get_state("config")
 
-    # Validate date format
     try:
         datetime.strptime(new_date, "%Y-%m-%d")
     except ValueError:
@@ -465,27 +521,11 @@ async def duplicate_event(
         async with ICUClient(config) as client:
             duplicated_event = await client.duplicate_event(event_id, new_date)
 
-            event_result: dict[str, Any] = {
-                "id": duplicated_event.id,
-                "start_date": duplicated_event.start_date_local,
-                "name": duplicated_event.name,
-                "category": duplicated_event.category,
-                "original_event_id": event_id,
-            }
-
-            if duplicated_event.description:
-                event_result["description"] = duplicated_event.description
-            if duplicated_event.type:
-                event_result["type"] = duplicated_event.type
-            if duplicated_event.moving_time:
-                event_result["duration_seconds"] = duplicated_event.moving_time
-            if duplicated_event.distance:
-                event_result["distance_meters"] = duplicated_event.distance
-            if duplicated_event.icu_training_load:
-                event_result["training_load"] = duplicated_event.icu_training_load
+            result = _event_to_dict(duplicated_event)
+            result["original_event_id"] = event_id
 
             return ResponseBuilder.build_response(
-                data=event_result,
+                data=result,
                 query_type="duplicate_event",
                 metadata={
                     "message": f"Successfully duplicated event {event_id} to {new_date}",

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -77,14 +77,25 @@ async def create_event(
         "Event category: WORKOUT, RACE_A, RACE_B, RACE_C, NOTE, PLAN, HOLIDAY, SICK, INJURED, "
         "SET_EFTP, FITNESS_DAYS, SEASON_START, TARGET, or SET_FITNESS",
     ],
-    description: Annotated[str | None, "Event description or Intervals.icu workout syntax"] = None,
+    description: Annotated[
+        str | None,
+        "Event description OR Intervals.icu workout text syntax for structured workouts. "
+        "To create a structured workout with power targets and visual bars, use the text syntax: "
+        "group headers as plain text lines, steps starting with '- <duration> <zone/power>'. "
+        "Duration formats: '10m', '30s', '1h30m'. Power: 'Z1'-'Z7' (zones), '80%' (FTP%), '200w', '179-243w' (range). "
+        "Repeats: '3x' before a group. "
+        "Example: 'Warmup\\n- 10m Z1\\n\\nMain Set\\n- 20m Z4\\n\\nCooldown\\n- 10m Z1'. "
+        "The API parses this into a full structured workout_doc automatically.",
+    ] = None,
     event_type: Annotated[str | None, "Activity type (e.g., Ride, Run, Swim)"] = None,
     duration_seconds: Annotated[int | None, "Planned duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Planned distance in meters"] = None,
     training_load: Annotated[int | None, "Planned training load"] = None,
     workout_doc: Annotated[
         str | None,
-        "JSON string of structured workout document with intervals and targets",
+        "JSON string of structured workout document. NOTE: Direct workout_doc JSON has limited "
+        "API support and does not render in the UI. Use the description field with Intervals.icu "
+        "text syntax instead to create structured workouts.",
     ] = None,
     tags: Annotated[
         str | None, "Comma-separated tags (e.g., 'intervals,threshold,tuesday')"
@@ -140,7 +151,7 @@ async def create_event(
 
     try:
         event_data: dict[str, Any] = {
-            "start_date_local": start_date,
+            "start_date_local": start_date + "T00:00:00",
             "name": name,
             "category": category.upper(),
         }
@@ -198,7 +209,14 @@ async def update_event(
     event_id: Annotated[int, "Event ID to update"],
     name: Annotated[str | None, "Updated event name"] = None,
     description: Annotated[
-        str | None, "Updated description or Intervals.icu workout syntax"
+        str | None,
+        "Updated description OR Intervals.icu workout text syntax for structured workouts. "
+        "To create a structured workout with power targets and visual bars, use the text syntax: "
+        "group headers as plain text lines, steps starting with '- <duration> <zone/power>'. "
+        "Duration formats: '10m', '30s', '1h30m'. Power: 'Z1'-'Z7' (zones), '80%' (FTP%), '200w', '179-243w' (range). "
+        "Repeats: '3x' before a group. "
+        "Example: 'Warmup\\n- 10m Z1\\n\\nMain Set\\n- 20m Z4\\n\\nCooldown\\n- 10m Z1'. "
+        "The API parses this into a full structured workout_doc automatically.",
     ] = None,
     start_date: Annotated[str | None, "Updated start date (YYYY-MM-DD)"] = None,
     event_type: Annotated[str | None, "Updated activity type"] = None,
@@ -207,7 +225,9 @@ async def update_event(
     training_load: Annotated[int | None, "Updated training load"] = None,
     workout_doc: Annotated[
         str | None,
-        "JSON string of updated structured workout document",
+        "JSON string of updated structured workout document. NOTE: Direct workout_doc JSON has "
+        "limited API support and does not render in the UI. Use the description field with "
+        "Intervals.icu text syntax instead to create structured workouts.",
     ] = None,
     tags: Annotated[str | None, "Updated comma-separated tags"] = None,
     indoor: Annotated[bool | None, "Whether this is an indoor workout"] = None,
@@ -419,6 +439,9 @@ async def bulk_create_events(
                     f"Event {i}: Invalid date format. Please use YYYY-MM-DD format.",
                     error_type="validation_error",
                 )
+
+            # API requires full datetime format
+            event_data["start_date_local"] = event_data["start_date_local"] + "T00:00:00"
 
         async with ICUClient(config) as client:
             created_events = await client.bulk_create_events(events_data)

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -14,7 +14,7 @@ async def create_event(
     start_date: Annotated[str, "Start date in YYYY-MM-DD format"],
     name: Annotated[str, "Event name"],
     category: Annotated[str, "Event category: WORKOUT, NOTE, RACE, or GOAL"],
-    description: Annotated[str | None, "Event description (optional)"] = None,
+    description: Annotated[str | None, "Event description. For WORKOUT events, use intervals.icu workout text syntax to create structured workouts with colored zone blocks. Format: section headers (Warmup/Main Set/Cooldown) on own lines, steps start with '- '. Power: N% (of FTP), Nw (watts), ZN (zone). HR: N% HR, ZN HR. Duration: Nm, Ns, Nh. Repeats: 'Main Set 3x'. Ramps: 'ramp 50-75%'. Cadence: Nrpm. Example: 'Warmup\\n- 10m 55%\\n\\nMain Set 3x\\n- 5m 95-105%\\n- 3m 50%\\n\\nCooldown\\n- 10m 45%'"] = None,
     event_type: Annotated[str | None, "Activity type (e.g., Ride, Run, Swim)"] = None,
     duration_seconds: Annotated[int | None, "Planned duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Planned distance in meters"] = None,
@@ -26,11 +26,15 @@ async def create_event(
     Adds an event to your Intervals.icu calendar. Events can be workouts with
     planned metrics, notes for tracking information, races, or training goals.
 
+    For structured workouts with colored zone blocks, put workout steps in the
+    description field using intervals.icu text syntax. The server will parse it
+    and generate the visual workout structure automatically.
+
     Args:
         start_date: Date in ISO-8601 format (YYYY-MM-DD)
         name: Name of the event
         category: Type of event - WORKOUT, NOTE, RACE, or GOAL
-        description: Optional detailed description
+        description: For workouts, use intervals.icu text syntax for structured steps
         event_type: Activity type (e.g., "Ride", "Run", "Swim") for workouts
         duration_seconds: Planned duration for workouts
         distance_meters: Planned distance for workouts
@@ -62,7 +66,7 @@ async def create_event(
     try:
         # Build event data
         event_data: dict[str, Any] = {
-            "start_date_local": start_date,
+            "start_date_local": f"{start_date}T00:00:00",
             "name": name,
             "category": category.upper(),
         }
@@ -164,7 +168,7 @@ async def update_event(
         if description is not None:
             event_data["description"] = description
         if start_date is not None:
-            event_data["start_date_local"] = start_date
+            event_data["start_date_local"] = f"{start_date}T00:00:00"
         if event_type is not None:
             event_data["type"] = event_type
         if duration_seconds is not None:
@@ -322,9 +326,10 @@ async def bulk_create_events(
             # Normalize category to uppercase
             event_data["category"] = event_data["category"].upper()
 
-            # Validate date format
+            # Validate date format and convert to full datetime
             try:
                 datetime.strptime(event_data["start_date_local"], "%Y-%m-%d")
+                event_data["start_date_local"] = f"{event_data['start_date_local']}T00:00:00"
             except ValueError:
                 return ResponseBuilder.build_error_response(
                     f"Event {i}: Invalid date format. Please use YYYY-MM-DD format.",
@@ -463,7 +468,7 @@ async def duplicate_event(
 
     try:
         async with ICUClient(config) as client:
-            duplicated_event = await client.duplicate_event(event_id, new_date)
+            duplicated_event = await client.duplicate_event(event_id, f"{new_date}T00:00:00")
 
             event_result: dict[str, Any] = {
                 "id": duplicated_event.id,

--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -81,6 +81,7 @@ async def get_calendar_events(
                     relative_timing = f"in_{days_until}_days"
 
                 event_item: dict[str, Any] = {
+                    "id": event.id,
                     "date": date,
                     "relative_timing": relative_timing,
                     "name": event.name or event.category or "Event",

--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -62,7 +62,8 @@ async def get_calendar_events(
             # Group events by date
             events_by_date: dict[str, list[dict[str, Any]]] = {}
             for event in events:
-                date = event.start_date_local
+                # start_date_local may be "YYYY-MM-DD" or "YYYY-MM-DDTHH:MM:SS"
+                date = event.start_date_local[:10]
                 if date not in events_by_date:
                     events_by_date[date] = []
 
@@ -189,7 +190,7 @@ async def get_upcoming_workouts(
 
             workouts_data: list[dict[str, Any]] = []
             for workout in workouts:
-                date_obj = datetime.strptime(workout.start_date_local, "%Y-%m-%d").date()
+                date_obj = datetime.strptime(workout.start_date_local[:10], "%Y-%m-%d").date()
                 today = datetime.now().date()
 
                 if date_obj == today:

--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -67,7 +67,7 @@ async def get_calendar_events(
                     events_by_date[date] = []
 
                 # Determine relative timing
-                date_obj = datetime.strptime(date, "%Y-%m-%d").date()
+                date_obj = datetime.fromisoformat(date).date()
                 today = datetime.now().date()
 
                 if date_obj == today:
@@ -189,7 +189,7 @@ async def get_upcoming_workouts(
 
             workouts_data: list[dict[str, Any]] = []
             for workout in workouts:
-                date_obj = datetime.strptime(workout.start_date_local, "%Y-%m-%d").date()
+                date_obj = datetime.fromisoformat(workout.start_date_local).date()
                 today = datetime.now().date()
 
                 if date_obj == today:

--- a/src/intervals_icu_mcp/tools/folder_management.py
+++ b/src/intervals_icu_mcp/tools/folder_management.py
@@ -1,0 +1,385 @@
+"""Workout folder and sharing management tools for Intervals.icu MCP server."""
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import Context
+
+from ..auth import ICUConfig
+from ..client import ICUAPIError, ICUClient
+from ..models import Folder
+from ..response_builder import ResponseBuilder
+
+VALID_FOLDER_TYPES = ["FOLDER", "PLAN"]
+VALID_VISIBILITIES = ["PRIVATE", "PUBLIC"]
+
+
+def _folder_to_dict(folder: Folder) -> dict[str, Any]:
+    """Build a response dict from a Folder model."""
+    result: dict[str, Any] = {
+        "id": folder.id,
+        "name": folder.name,
+    }
+    if folder.type:
+        result["type"] = folder.type
+    if folder.description:
+        result["description"] = folder.description
+    if folder.visibility:
+        result["visibility"] = folder.visibility
+    if folder.blurb:
+        result["blurb"] = folder.blurb
+    if folder.num_workouts is not None:
+        result["num_workouts"] = folder.num_workouts
+    if folder.start_date_local:
+        result["start_date"] = folder.start_date_local
+    if folder.duration_weeks is not None:
+        result["duration_weeks"] = folder.duration_weeks
+    if folder.hours_per_week_min or folder.hours_per_week_max:
+        result["hours_per_week"] = {
+            "min": folder.hours_per_week_min,
+            "max": folder.hours_per_week_max,
+        }
+    if folder.rollout_weeks is not None:
+        result["rollout_weeks"] = folder.rollout_weeks
+    if folder.starting_ctl is not None:
+        result["starting_ctl"] = folder.starting_ctl
+    if folder.starting_atl is not None:
+        result["starting_atl"] = folder.starting_atl
+    if folder.activity_types:
+        result["activity_types"] = folder.activity_types
+    if folder.workout_targets:
+        result["workout_targets"] = folder.workout_targets
+    if folder.read_only_workouts is not None:
+        result["read_only_workouts"] = folder.read_only_workouts
+    return result
+
+
+async def create_folder(
+    name: Annotated[str, "Folder or training plan name"],
+    folder_type: Annotated[str, "FOLDER for a simple folder, PLAN for a training plan"] = "FOLDER",
+    description: Annotated[str | None, "Description of the folder or plan"] = None,
+    visibility: Annotated[str | None, "Visibility: PRIVATE or PUBLIC"] = None,
+    copy_folder_id: Annotated[int | None, "Copy workouts from an existing folder ID"] = None,
+    start_date: Annotated[str | None, "Plan start date (YYYY-MM-DD), for PLAN type"] = None,
+    rollout_weeks: Annotated[int | None, "Number of weeks to roll out the plan"] = None,
+    starting_ctl: Annotated[int | None, "Starting CTL (fitness) for the plan"] = None,
+    starting_atl: Annotated[int | None, "Starting ATL (fatigue) for the plan"] = None,
+    blurb: Annotated[str | None, "Short marketing description for the plan"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Create a new workout folder or training plan.
+
+    Folders organize workouts in your library. Training plans (PLAN type) can be
+    assigned a start date and scheduled onto an athlete's calendar.
+
+    Returns:
+        JSON string with created folder data
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    if folder_type.upper() not in VALID_FOLDER_TYPES:
+        return ResponseBuilder.build_error_response(
+            f"Invalid folder_type. Must be one of: {', '.join(VALID_FOLDER_TYPES)}",
+            error_type="validation_error",
+        )
+
+    if visibility and visibility.upper() not in VALID_VISIBILITIES:
+        return ResponseBuilder.build_error_response(
+            f"Invalid visibility. Must be one of: {', '.join(VALID_VISIBILITIES)}",
+            error_type="validation_error",
+        )
+
+    try:
+        folder_data: dict[str, Any] = {
+            "name": name,
+            "type": folder_type.upper(),
+        }
+
+        if description is not None:
+            folder_data["description"] = description
+        if visibility is not None:
+            folder_data["visibility"] = visibility.upper()
+        if copy_folder_id is not None:
+            folder_data["copy_folder_id"] = copy_folder_id
+        if start_date is not None:
+            folder_data["start_date_local"] = start_date
+        if rollout_weeks is not None:
+            folder_data["rollout_weeks"] = rollout_weeks
+        if starting_ctl is not None:
+            folder_data["starting_ctl"] = starting_ctl
+        if starting_atl is not None:
+            folder_data["starting_atl"] = starting_atl
+        if blurb is not None:
+            folder_data["blurb"] = blurb
+
+        async with ICUClient(config) as client:
+            folder = await client.create_folder(folder_data)
+
+            return ResponseBuilder.build_response(
+                data=_folder_to_dict(folder),
+                query_type="create_folder",
+                metadata={"message": f"Successfully created {folder_type.lower()}: {name}"},
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def update_folder(
+    folder_id: Annotated[int, "Folder ID to update"],
+    name: Annotated[str | None, "Updated folder name"] = None,
+    description: Annotated[str | None, "Updated description"] = None,
+    visibility: Annotated[str | None, "Updated visibility: PRIVATE or PUBLIC"] = None,
+    start_date: Annotated[str | None, "Updated plan start date (YYYY-MM-DD)"] = None,
+    rollout_weeks: Annotated[int | None, "Updated rollout weeks"] = None,
+    starting_ctl: Annotated[int | None, "Updated starting CTL"] = None,
+    starting_atl: Annotated[int | None, "Updated starting ATL"] = None,
+    blurb: Annotated[str | None, "Updated short description"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Update an existing folder or training plan.
+
+    Only provide the fields you want to change — others remain unchanged.
+
+    Returns:
+        JSON string with updated folder data
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    if visibility and visibility.upper() not in VALID_VISIBILITIES:
+        return ResponseBuilder.build_error_response(
+            f"Invalid visibility. Must be one of: {', '.join(VALID_VISIBILITIES)}",
+            error_type="validation_error",
+        )
+
+    try:
+        folder_data: dict[str, Any] = {}
+
+        if name is not None:
+            folder_data["name"] = name
+        if description is not None:
+            folder_data["description"] = description
+        if visibility is not None:
+            folder_data["visibility"] = visibility.upper()
+        if start_date is not None:
+            folder_data["start_date_local"] = start_date
+        if rollout_weeks is not None:
+            folder_data["rollout_weeks"] = rollout_weeks
+        if starting_ctl is not None:
+            folder_data["starting_ctl"] = starting_ctl
+        if starting_atl is not None:
+            folder_data["starting_atl"] = starting_atl
+        if blurb is not None:
+            folder_data["blurb"] = blurb
+
+        if not folder_data:
+            return ResponseBuilder.build_error_response(
+                "No fields provided to update.", error_type="validation_error"
+            )
+
+        async with ICUClient(config) as client:
+            folder = await client.update_folder(folder_id, folder_data)
+
+            return ResponseBuilder.build_response(
+                data=_folder_to_dict(folder),
+                query_type="update_folder",
+                metadata={"message": f"Successfully updated folder {folder_id}"},
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def delete_folder(
+    folder_id: Annotated[int, "Folder ID to delete"],
+    ctx: Context | None = None,
+) -> str:
+    """Delete a folder and all workouts inside it.
+
+    Permanently removes the folder and all its workouts. Cannot be undone.
+
+    Returns:
+        JSON string with deletion confirmation
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            await client.delete_folder(folder_id)
+
+            return ResponseBuilder.build_response(
+                data={"folder_id": folder_id, "deleted": True},
+                query_type="delete_folder",
+                metadata={
+                    "message": f"Successfully deleted folder {folder_id} and all its workouts"
+                },
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def update_plan_workouts(
+    folder_id: Annotated[int, "Folder/plan ID whose workouts to update"],
+    hide_from_athlete: Annotated[bool | None, "Set visibility for all matching workouts"] = None,
+    oldest: Annotated[str | None, "Oldest date in range to update (YYYY-MM-DD)"] = None,
+    newest: Annotated[str | None, "Newest date in range to update (YYYY-MM-DD)"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Batch update workouts on a training plan.
+
+    Updates properties on multiple workouts at once, optionally restricted to
+    a date range. Useful for bulk-hiding workouts from an athlete.
+
+    Returns:
+        JSON string with updated workout count
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        workout_data: dict[str, Any] = {}
+
+        if hide_from_athlete is not None:
+            workout_data["hide_from_athlete"] = hide_from_athlete
+
+        if not workout_data:
+            return ResponseBuilder.build_error_response(
+                "No fields provided to update.", error_type="validation_error"
+            )
+
+        async with ICUClient(config) as client:
+            updated = await client.update_plan_workouts(
+                folder_id, workout_data, oldest=oldest, newest=newest
+            )
+
+            return ResponseBuilder.build_response(
+                data={"folder_id": folder_id, "updated_count": len(updated)},
+                query_type="update_plan_workouts",
+                metadata={
+                    "message": f"Successfully updated {len(updated)} workouts in folder {folder_id}"
+                },
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def get_folder_sharing(
+    folder_id: Annotated[int, "Folder ID to get sharing info for"],
+    ctx: Context | None = None,
+) -> str:
+    """List athletes a folder is shared with.
+
+    Returns:
+        JSON string with list of athletes who have access to the folder
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            shared_with = await client.get_folder_shared_with(folder_id)
+
+            athletes = [
+                {
+                    "id": sw.id,
+                    "name": sw.name,
+                    "email": sw.email,
+                    "can_edit": sw.can_edit,
+                }
+                for sw in shared_with
+            ]
+
+            return ResponseBuilder.build_response(
+                data={"folder_id": folder_id, "shared_with": athletes, "count": len(athletes)},
+                query_type="get_folder_sharing",
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def update_folder_sharing(
+    folder_id: Annotated[int, "Folder ID to update sharing for"],
+    athletes: Annotated[
+        str,
+        'JSON array of athlete share objects, e.g. [{"id": "athlete123", "canEdit": false}]. '
+        "To remove sharing, provide an empty array [].",
+    ],
+    ctx: Context | None = None,
+) -> str:
+    """Add or remove athletes from a folder's share list.
+
+    Replaces the current share list with the provided list. To remove all sharing,
+    provide an empty array.
+
+    Returns:
+        JSON string with updated share list
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        try:
+            parsed = json.loads(athletes)
+        except json.JSONDecodeError as e:
+            return ResponseBuilder.build_error_response(
+                f"Invalid JSON format: {str(e)}", error_type="validation_error"
+            )
+
+        if not isinstance(parsed, list):
+            return ResponseBuilder.build_error_response(
+                "athletes must be a JSON array", error_type="validation_error"
+            )
+
+        share_list: list[dict[str, Any]] = parsed  # type: ignore[assignment]
+
+        async with ICUClient(config) as client:
+            updated = await client.update_folder_shared_with(folder_id, share_list)
+
+            result = [
+                {
+                    "id": sw.id,
+                    "name": sw.name,
+                    "email": sw.email,
+                    "can_edit": sw.can_edit,
+                }
+                for sw in updated
+            ]
+
+            return ResponseBuilder.build_response(
+                data={"folder_id": folder_id, "shared_with": result, "count": len(result)},
+                query_type="update_folder_sharing",
+                metadata={"message": f"Successfully updated sharing for folder {folder_id}"},
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )

--- a/src/intervals_icu_mcp/tools/gear.py
+++ b/src/intervals_icu_mcp/tools/gear.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 
 from fastmcp import Context
 
-from ..auth import load_config, validate_credentials
+from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
 
@@ -17,11 +17,8 @@ async def get_gear_list(
     Returns:
         Formatted list of all gear with details, usage stats, and reminders
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -131,11 +128,8 @@ async def create_gear(
     Returns:
         Created gear item with ID and initial stats
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -201,11 +195,8 @@ async def update_gear(
     Returns:
         Updated gear item details
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -283,11 +274,8 @@ async def delete_gear(
     Returns:
         Deletion confirmation
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -327,11 +315,8 @@ async def create_gear_reminder(
     Returns:
         Created reminder details
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -398,11 +383,8 @@ async def update_gear_reminder(
     Returns:
         Updated reminder details
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:

--- a/src/intervals_icu_mcp/tools/performance.py
+++ b/src/intervals_icu_mcp/tools/performance.py
@@ -16,6 +16,10 @@ async def get_power_curves(
         str | None,
         "Time period shorthand: 'week', 'month', 'year', 'all' (optional)",
     ] = None,
+    sport_type: Annotated[
+        str,
+        "Sport type to get curves for: 'Ride', 'Run', 'Swim', 'VirtualRide', etc. Default is 'Ride'",
+    ] = "Ride",
     ctx: Context | None = None,
 ) -> str:
     """Get power curve data showing best efforts for various durations.
@@ -30,6 +34,7 @@ async def get_power_curves(
         days_back: Number of days to analyze (overrides time_period)
         time_period: Time period shorthand - 'week' (7 days), 'month' (30 days),
                      'year' (365 days), 'all' (all time). Default is 90 days.
+        sport_type: Sport type (e.g. 'Ride', 'Run', 'Swim', 'VirtualRide'). Default is 'Ride'.
 
     Returns:
         JSON string with power curve data
@@ -71,9 +76,9 @@ async def get_power_curves(
             period_label = "90_days"
 
         async with ICUClient(config) as client:
-            power_curve = await client.get_power_curves(oldest=oldest)
+            power_curve = await client.get_power_curves(oldest=oldest, sport_type=sport_type)
 
-            if not power_curve.data or len(power_curve.data) == 0:
+            if not power_curve.secs or not power_curve.values:
                 return ResponseBuilder.build_response(
                     data={"power_curve": [], "period": period_label},
                     metadata={
@@ -81,6 +86,13 @@ async def get_power_curves(
                         "Complete some rides with power to build your power curve."
                     },
                 )
+
+            # Build list of (secs, watts, activity_id) tuples for easy lookup
+            act_ids = power_curve.activity_id or []
+            points = [
+                (s, w, act_ids[i] if i < len(act_ids) else None)
+                for i, (s, w) in enumerate(zip(power_curve.secs, power_curve.values, strict=True))
+            ]
 
             # Key durations to highlight (in seconds)
             key_durations = {
@@ -98,60 +110,44 @@ async def get_power_curves(
             # Find data points for key durations
             peak_efforts: dict[str, dict[str, Any]] = {}
             for seconds, label in key_durations.items():
-                # Find closest data point
-                closest_point = min(
-                    power_curve.data,
-                    key=lambda p: abs(p.secs - seconds),
-                    default=None,
-                )
-
-                if closest_point and abs(closest_point.secs - seconds) <= seconds * 0.1:
-                    # Only include if within 10% of target duration
+                closest = min(points, key=lambda p: abs(p[0] - seconds), default=None)
+                if closest and abs(closest[0] - seconds) <= seconds * 0.1:
                     effort: dict[str, Any] = {
-                        "watts": closest_point.watts,
-                        "duration_seconds": closest_point.secs,
+                        "watts": closest[1],
+                        "duration_seconds": closest[0],
                     }
-                    if closest_point.date:
-                        effort["date"] = closest_point.date
-                    if closest_point.src_activity_id:
-                        effort["activity_id"] = closest_point.src_activity_id
-
+                    if closest[2]:
+                        effort["activity_id"] = closest[2]
                     peak_efforts[label] = effort
 
             # Calculate summary statistics
-            max_power_point = max(power_curve.data, key=lambda p: p.watts or 0)
-            min_duration = min(power_curve.data, key=lambda p: p.secs)
-            max_duration = max(power_curve.data, key=lambda p: p.secs)
+            max_watts = max(power_curve.values)
+            max_idx = power_curve.values.index(max_watts)
 
             summary: dict[str, Any] = {
-                "total_data_points": len(power_curve.data),
-                "max_power_watts": max_power_point.watts,
-                "max_power_duration_seconds": max_power_point.secs,
+                "total_data_points": len(power_curve.secs),
+                "max_power_watts": max_watts,
+                "max_power_duration_seconds": power_curve.secs[max_idx],
                 "duration_range": {
-                    "min_seconds": min_duration.secs,
-                    "max_seconds": max_duration.secs,
+                    "min_seconds": power_curve.secs[0],
+                    "max_seconds": power_curve.secs[-1],
                 },
             }
 
-            # If we have dates, show range
-            dates = [p.date for p in power_curve.data if p.date]
-            if dates:
-                summary["effort_date_range"] = {"oldest": min(dates), "newest": max(dates)}
+            if power_curve.start_date_local and power_curve.end_date_local:
+                summary["effort_date_range"] = {
+                    "oldest": power_curve.start_date_local,
+                    "newest": power_curve.end_date_local,
+                }
 
-            # Calculate FTP and power zones (based on 20-min power)
-            twenty_min_point = min(
-                power_curve.data,
-                key=lambda p: abs(p.secs - 1200),
-                default=None,
-            )
+            # Calculate FTP estimate and power zones (based on 20-min power)
+            closest_20min = min(points, key=lambda p: abs(p[0] - 1200), default=None)
 
             ftp_analysis = None
-            if twenty_min_point and abs(twenty_min_point.secs - 1200) <= 120:
-                # Estimate FTP as 95% of 20-min power
-                estimated_ftp = int((twenty_min_point.watts or 0) * 0.95)
+            if closest_20min and abs(closest_20min[0] - 1200) <= 120:
+                estimated_ftp = int((closest_20min[1] or 0) * 0.95)
 
                 if estimated_ftp > 0:
-                    # Power zones
                     zones = {
                         "recovery": (0, 0.55),
                         "endurance": (0.56, 0.75),
@@ -171,7 +167,7 @@ async def get_power_curves(
                         }
 
                     ftp_analysis = {
-                        "twenty_min_power": twenty_min_point.watts,
+                        "twenty_min_power": closest_20min[1],
                         "estimated_ftp": estimated_ftp,
                         "power_zones": power_zones,
                     }

--- a/src/intervals_icu_mcp/tools/performance.py
+++ b/src/intervals_icu_mcp/tools/performance.py
@@ -16,6 +16,10 @@ async def get_power_curves(
         str | None,
         "Time period shorthand: 'week', 'month', 'year', 'all' (optional)",
     ] = None,
+    sport_type: Annotated[
+        str | None,
+        "Activity type: 'Ride', 'Run', 'Swim', etc. (optional, defaults to Ride)",
+    ] = None,
     ctx: Context | None = None,
 ) -> str:
     """Get power curve data showing best efforts for various durations.
@@ -71,7 +75,7 @@ async def get_power_curves(
             period_label = "90_days"
 
         async with ICUClient(config) as client:
-            power_curve = await client.get_power_curves(oldest=oldest)
+            power_curve = await client.get_power_curves(oldest=oldest, sport_type=sport_type)
 
             if not power_curve.data or len(power_curve.data) == 0:
                 return ResponseBuilder.build_response(

--- a/src/intervals_icu_mcp/tools/sport_settings.py
+++ b/src/intervals_icu_mcp/tools/sport_settings.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 
 from fastmcp import Context
 
-from ..auth import load_config, validate_credentials
+from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
 
@@ -17,11 +17,8 @@ async def get_sport_settings(
     Returns:
         Formatted list of sport settings with thresholds and zones
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -100,11 +97,8 @@ async def update_sport_settings(
     Returns:
         Updated sport settings
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -179,11 +173,8 @@ async def apply_sport_settings(
     Returns:
         Result of applying settings
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -227,11 +218,8 @@ async def create_sport_settings(
     Returns:
         Created sport settings
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:
@@ -294,11 +282,8 @@ async def delete_sport_settings(
     Returns:
         Deletion confirmation
     """
-    config = load_config()
-    if not validate_credentials(config):
-        return (
-            "Error: Intervals.icu credentials not configured. Run intervals-icu-mcp-auth to set up."
-        )
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
 
     try:
         async with ICUClient(config) as client:

--- a/src/intervals_icu_mcp/tools/training_plan.py
+++ b/src/intervals_icu_mcp/tools/training_plan.py
@@ -1,0 +1,165 @@
+"""Training plan management tools for Intervals.icu MCP server."""
+
+from datetime import datetime
+from typing import Annotated, Any
+
+from fastmcp import Context
+
+from ..auth import ICUConfig
+from ..client import ICUAPIError, ICUClient
+from ..models import AthleteTrainingPlan
+from ..response_builder import ResponseBuilder
+
+
+def _plan_to_dict(plan: AthleteTrainingPlan) -> dict[str, Any]:
+    """Build a response dict from an AthleteTrainingPlan model."""
+    result: dict[str, Any] = {}
+    if plan.id:
+        result["athlete_id"] = plan.id
+    if plan.training_plan_id is not None:
+        result["training_plan_id"] = plan.training_plan_id
+    if plan.training_plan_alias:
+        result["alias"] = plan.training_plan_alias
+    if plan.training_plan_start_date:
+        result["start_date"] = plan.training_plan_start_date
+    if plan.training_plan_last_applied:
+        result["last_applied"] = plan.training_plan_last_applied
+    if plan.timezone:
+        result["timezone"] = plan.timezone
+    if plan.training_plan:
+        result["plan"] = {
+            "id": plan.training_plan.id,
+            "name": plan.training_plan.name,
+            "description": plan.training_plan.description,
+            "duration_weeks": plan.training_plan.duration_weeks,
+            "hours_per_week": {
+                "min": plan.training_plan.hours_per_week_min,
+                "max": plan.training_plan.hours_per_week_max,
+            },
+            "num_workouts": plan.training_plan.num_workouts,
+        }
+    return result
+
+
+async def get_training_plan(
+    ctx: Context | None = None,
+) -> str:
+    """Get the athlete's current training plan assignment.
+
+    Returns the active training plan including plan details, start date,
+    and last time plan changes were applied to the calendar.
+
+    Returns:
+        JSON string with current training plan details
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            plan = await client.get_training_plan()
+
+            if not plan.training_plan_id:
+                return ResponseBuilder.build_response(
+                    data={"training_plan": None},
+                    metadata={"message": "No training plan currently assigned"},
+                )
+
+            return ResponseBuilder.build_response(
+                data={"training_plan": _plan_to_dict(plan)},
+                query_type="get_training_plan",
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def set_training_plan(
+    training_plan_id: Annotated[
+        int, "Folder ID of the training plan to assign (use get_workout_library to find IDs)"
+    ],
+    start_date: Annotated[str, "Plan start date in YYYY-MM-DD format"],
+    alias: Annotated[str | None, "Optional custom name for this plan instance"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Set or change the athlete's training plan.
+
+    Assigns a training plan folder to the athlete starting on the given date.
+    Use apply_plan_changes after setting to push the plan workouts to the calendar.
+
+    Returns:
+        JSON string with updated training plan assignment
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        datetime.strptime(start_date, "%Y-%m-%d")
+    except ValueError:
+        return ResponseBuilder.build_error_response(
+            "Invalid date format. Please use YYYY-MM-DD format.",
+            error_type="validation_error",
+        )
+
+    try:
+        plan_data: dict[str, Any] = {
+            "training_plan_id": training_plan_id,
+            "training_plan_start_date": start_date,
+        }
+        if alias is not None:
+            plan_data["training_plan_alias"] = alias
+
+        async with ICUClient(config) as client:
+            plan = await client.set_training_plan(plan_data)
+
+            return ResponseBuilder.build_response(
+                data={"training_plan": _plan_to_dict(plan)},
+                query_type="set_training_plan",
+                metadata={
+                    "message": f"Successfully assigned training plan {training_plan_id} starting {start_date}. "
+                    "Run apply_plan_changes to push workouts to your calendar."
+                },
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def apply_plan_changes(
+    ctx: Context | None = None,
+) -> str:
+    """Apply pending training plan changes to the calendar.
+
+    Syncs the current training plan to the athlete's calendar, adding or updating
+    planned workouts. Run this after set_training_plan or after modifying plan workouts.
+
+    Returns:
+        JSON string with result of applying the plan
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            result = await client.apply_plan_changes()
+
+            return ResponseBuilder.build_response(
+                data=result,
+                query_type="apply_plan_changes",
+                metadata={"message": "Successfully applied training plan changes to calendar"},
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )

--- a/src/intervals_icu_mcp/tools/workout_library.py
+++ b/src/intervals_icu_mcp/tools/workout_library.py
@@ -1,12 +1,67 @@
 """Workout library tools for Intervals.icu MCP server."""
 
+import base64
+import json
 from typing import Annotated, Any
 
 from fastmcp import Context
 
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
+from ..models import Workout
 from ..response_builder import ResponseBuilder
+
+
+def _workout_to_dict(workout: Workout) -> dict[str, Any]:
+    """Build a response dict from a Workout model, including all populated fields."""
+    result: dict[str, Any] = {
+        "id": workout.id,
+        "name": workout.name,
+    }
+    if workout.folder_id is not None:
+        result["folder_id"] = workout.folder_id
+    if workout.description:
+        result["description"] = workout.description
+    if workout.type:
+        result["type"] = workout.type
+    if workout.indoor is not None:
+        result["indoor"] = workout.indoor
+    if workout.color:
+        result["color"] = workout.color
+    if workout.target:
+        result["target"] = workout.target
+    if workout.tags:
+        result["tags"] = workout.tags
+    if workout.sub_type:
+        result["sub_type"] = workout.sub_type
+    if workout.day is not None:
+        result["day"] = workout.day
+    if workout.for_week is not None:
+        result["for_week"] = workout.for_week
+    if workout.hide_from_athlete is not None:
+        result["hide_from_athlete"] = workout.hide_from_athlete
+    if workout.updated:
+        result["updated"] = workout.updated
+    if workout.workout_doc:
+        result["workout_doc"] = workout.workout_doc
+
+    metrics: dict[str, Any] = {}
+    if workout.moving_time:
+        metrics["duration_seconds"] = workout.moving_time
+    if workout.distance:
+        metrics["distance_meters"] = workout.distance
+    if workout.icu_training_load:
+        metrics["training_load"] = workout.icu_training_load
+    if workout.icu_intensity:
+        metrics["intensity_factor"] = workout.icu_intensity
+    if workout.joules:
+        metrics["joules"] = workout.joules
+    if workout.joules_above_ftp:
+        metrics["joules_above_ftp"] = workout.joules_above_ftp
+    if metrics:
+        result["metrics"] = metrics
+
+    return result
 
 
 async def get_workout_library(
@@ -16,8 +71,6 @@ async def get_workout_library(
 
     Returns all workout folders and training plans available to you, including
     your personal workouts, shared workouts, and any training plans you follow.
-
-    Each folder contains structured workouts that can be applied to your calendar.
 
     Returns:
         JSON string with workout folders/plans
@@ -48,6 +101,12 @@ async def get_workout_library(
                     folder_item["description"] = folder.description
                 if folder.num_workouts:
                     folder_item["num_workouts"] = folder.num_workouts
+                if folder.type:
+                    folder_item["type"] = folder.type
+                if folder.visibility:
+                    folder_item["visibility"] = folder.visibility
+                if folder.blurb:
+                    folder_item["blurb"] = folder.blurb
 
                 # Training plan info
                 if folder.start_date_local:
@@ -62,7 +121,6 @@ async def get_workout_library(
 
                 folders_data.append(folder_item)
 
-            # Categorize folders
             training_plans = [f for f in folders if f.duration_weeks is not None]
             regular_folders = [f for f in folders if f.duration_weeks is None]
 
@@ -73,13 +131,8 @@ async def get_workout_library(
                 "total_workouts": sum(f.num_workouts or 0 for f in folders),
             }
 
-            result_data = {
-                "folders": folders_data,
-                "summary": summary,
-            }
-
             return ResponseBuilder.build_response(
-                data=result_data,
+                data={"folders": folders_data, "summary": summary},
                 query_type="workout_library",
             )
 
@@ -100,9 +153,6 @@ async def get_workouts_in_folder(
     Returns detailed information about all workouts stored in a folder,
     including their structure, intensity, and training load.
 
-    Args:
-        folder_id: ID of the folder to browse
-
     Returns:
         JSON string with workout details
     """
@@ -119,45 +169,8 @@ async def get_workouts_in_folder(
                     metadata={"message": f"No workouts found in folder {folder_id}"},
                 )
 
-            workouts_data: list[dict[str, Any]] = []
-            for workout in workouts:
-                workout_item: dict[str, Any] = {
-                    "id": workout.id,
-                    "name": workout.name,
-                }
+            workouts_data = [_workout_to_dict(w) for w in workouts]
 
-                if workout.description:
-                    workout_item["description"] = workout.description
-                if workout.type:
-                    workout_item["type"] = workout.type
-
-                # Workout metrics
-                metrics: dict[str, Any] = {}
-                if workout.moving_time:
-                    metrics["duration_seconds"] = workout.moving_time
-                if workout.distance:
-                    metrics["distance_meters"] = workout.distance
-                if workout.icu_training_load:
-                    metrics["training_load"] = workout.icu_training_load
-                if workout.icu_intensity:
-                    metrics["intensity_factor"] = workout.icu_intensity
-                if workout.joules:
-                    metrics["joules"] = workout.joules
-                if workout.joules_above_ftp:
-                    metrics["joules_above_ftp"] = workout.joules_above_ftp
-
-                if metrics:
-                    workout_item["metrics"] = metrics
-
-                # Other properties
-                if workout.indoor is not None:
-                    workout_item["indoor"] = workout.indoor
-                if workout.color:
-                    workout_item["color"] = workout.color
-
-                workouts_data.append(workout_item)
-
-            # Calculate summary
             total_duration = sum(w.moving_time or 0 for w in workouts)
             total_load = sum(w.icu_training_load or 0 for w in workouts)
             indoor_count = sum(1 for w in workouts if w.indoor)
@@ -169,15 +182,519 @@ async def get_workouts_in_folder(
                 "indoor_workouts": indoor_count,
             }
 
-            result_data = {
-                "folder_id": folder_id,
-                "workouts": workouts_data,
-                "summary": summary,
-            }
+            return ResponseBuilder.build_response(
+                data={"folder_id": folder_id, "workouts": workouts_data, "summary": summary},
+                query_type="folder_workouts",
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def get_workout(
+    workout_id: Annotated[int, "Workout ID"],
+    ctx: Context | None = None,
+) -> str:
+    """Get a single workout by ID, including its full structured definition.
+
+    Returns all workout details including the workout_doc with intervals and targets.
+
+    Returns:
+        JSON string with workout details
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            workout = await client.get_workout(workout_id)
 
             return ResponseBuilder.build_response(
-                data=result_data,
-                query_type="folder_workouts",
+                data=_workout_to_dict(workout),
+                query_type="get_workout",
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def create_workout(
+    folder_id: Annotated[int, "Folder ID to create the workout in"],
+    name: Annotated[str, "Workout name"],
+    workout_doc: Annotated[
+        str | None,
+        "JSON string of structured workout document with intervals and targets",
+    ] = None,
+    description: Annotated[str | None, "Workout description"] = None,
+    event_type: Annotated[str | None, "Activity type (e.g., Ride, Run, Swim)"] = None,
+    duration_seconds: Annotated[int | None, "Planned duration in seconds"] = None,
+    distance_meters: Annotated[float | None, "Planned distance in meters"] = None,
+    target: Annotated[str | None, "Target metric: AUTO, POWER, HR, or PACE"] = None,
+    tags: Annotated[str | None, "Comma-separated tags (e.g., 'intervals,threshold')"] = None,
+    indoor: Annotated[bool | None, "Whether this is an indoor workout"] = None,
+    sub_type: Annotated[str | None, "Sub-type: NONE, COMMUTE, WARMUP, COOLDOWN, or RACE"] = None,
+    day: Annotated[int | None, "Day number for placement in a training plan"] = None,
+    color: Annotated[str | None, "Workout color hex code (e.g., '#FF5733')"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Create a new workout in a folder or training plan.
+
+    Use workout_doc to define structured intervals with power/HR/pace targets.
+    The workout will appear in the folder and can be scheduled to the calendar.
+
+    Returns:
+        JSON string with created workout data
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        workout_data: dict[str, Any] = {
+            "folder_id": folder_id,
+            "name": name,
+        }
+
+        if description is not None:
+            workout_data["description"] = description
+        if event_type is not None:
+            workout_data["type"] = event_type
+        if duration_seconds is not None:
+            workout_data["moving_time"] = duration_seconds
+        if distance_meters is not None:
+            workout_data["distance"] = distance_meters
+        if target is not None:
+            workout_data["target"] = target.upper()
+        if indoor is not None:
+            workout_data["indoor"] = indoor
+        if sub_type is not None:
+            workout_data["sub_type"] = sub_type.upper()
+        if day is not None:
+            workout_data["day"] = day
+        if color is not None:
+            workout_data["color"] = color
+        if tags is not None:
+            workout_data["tags"] = [t.strip() for t in tags.split(",") if t.strip()]
+        if workout_doc is not None:
+            try:
+                workout_data["workout_doc"] = json.loads(workout_doc)
+            except json.JSONDecodeError as e:
+                return ResponseBuilder.build_error_response(
+                    f"Invalid workout_doc JSON: {str(e)}", error_type="validation_error"
+                )
+
+        async with ICUClient(config) as client:
+            workout = await client.create_workout(workout_data)
+
+            return ResponseBuilder.build_response(
+                data=_workout_to_dict(workout),
+                query_type="create_workout",
+                metadata={"message": f"Successfully created workout: {name}"},
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def update_workout(
+    workout_id: Annotated[int, "Workout ID to update"],
+    name: Annotated[str | None, "Updated workout name"] = None,
+    workout_doc: Annotated[str | None, "JSON string of updated structured workout document"] = None,
+    description: Annotated[str | None, "Updated description"] = None,
+    event_type: Annotated[str | None, "Updated activity type"] = None,
+    duration_seconds: Annotated[int | None, "Updated duration in seconds"] = None,
+    distance_meters: Annotated[float | None, "Updated distance in meters"] = None,
+    target: Annotated[str | None, "Updated target metric: AUTO, POWER, HR, or PACE"] = None,
+    tags: Annotated[str | None, "Updated comma-separated tags"] = None,
+    indoor: Annotated[bool | None, "Updated indoor flag"] = None,
+    sub_type: Annotated[str | None, "Updated sub-type"] = None,
+    color: Annotated[str | None, "Updated color hex code"] = None,
+    hide_from_athlete: Annotated[bool | None, "Hide this workout from the athlete"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Update an existing workout.
+
+    Only provide the fields you want to change — others remain unchanged.
+
+    Returns:
+        JSON string with updated workout data
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        workout_data: dict[str, Any] = {}
+
+        if name is not None:
+            workout_data["name"] = name
+        if description is not None:
+            workout_data["description"] = description
+        if event_type is not None:
+            workout_data["type"] = event_type
+        if duration_seconds is not None:
+            workout_data["moving_time"] = duration_seconds
+        if distance_meters is not None:
+            workout_data["distance"] = distance_meters
+        if target is not None:
+            workout_data["target"] = target.upper()
+        if indoor is not None:
+            workout_data["indoor"] = indoor
+        if sub_type is not None:
+            workout_data["sub_type"] = sub_type.upper()
+        if color is not None:
+            workout_data["color"] = color
+        if hide_from_athlete is not None:
+            workout_data["hide_from_athlete"] = hide_from_athlete
+        if tags is not None:
+            workout_data["tags"] = [t.strip() for t in tags.split(",") if t.strip()]
+        if workout_doc is not None:
+            try:
+                workout_data["workout_doc"] = json.loads(workout_doc)
+            except json.JSONDecodeError as e:
+                return ResponseBuilder.build_error_response(
+                    f"Invalid workout_doc JSON: {str(e)}", error_type="validation_error"
+                )
+
+        if not workout_data:
+            return ResponseBuilder.build_error_response(
+                "No fields provided to update.", error_type="validation_error"
+            )
+
+        async with ICUClient(config) as client:
+            workout = await client.update_workout(workout_id, workout_data)
+
+            return ResponseBuilder.build_response(
+                data=_workout_to_dict(workout),
+                query_type="update_workout",
+                metadata={"message": f"Successfully updated workout {workout_id}"},
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def delete_workout(
+    workout_id: Annotated[int, "Workout ID to delete"],
+    delete_related: Annotated[
+        bool, "Also delete workouts added at the same time on a training plan"
+    ] = False,
+    ctx: Context | None = None,
+) -> str:
+    """Delete a workout from the library.
+
+    Permanently removes a workout. Cannot be undone.
+
+    Returns:
+        JSON string with deletion confirmation
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            await client.delete_workout(workout_id, delete_related=delete_related)
+
+            return ResponseBuilder.build_response(
+                data={"workout_id": workout_id, "deleted": True},
+                query_type="delete_workout",
+                metadata={"message": f"Successfully deleted workout {workout_id}"},
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def bulk_create_workouts(
+    workouts: Annotated[
+        str,
+        "JSON array of workout objects. Each must have: folder_id, name. "
+        "Optional: workout_doc, description, type, moving_time, distance, target, tags, indoor, day",
+    ],
+    ctx: Context | None = None,
+) -> str:
+    """Create multiple workouts in a single operation.
+
+    More efficient than creating workouts one at a time.
+
+    Returns:
+        JSON string with created workouts and count
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        try:
+            parsed_data = json.loads(workouts)
+        except json.JSONDecodeError as e:
+            return ResponseBuilder.build_error_response(
+                f"Invalid JSON format: {str(e)}", error_type="validation_error"
+            )
+
+        if not isinstance(parsed_data, list):
+            return ResponseBuilder.build_error_response(
+                "Workouts must be a JSON array", error_type="validation_error"
+            )
+
+        workouts_data: list[dict[str, Any]] = parsed_data  # type: ignore[assignment]
+
+        for i, workout_data in enumerate(workouts_data):
+            if "folder_id" not in workout_data:
+                return ResponseBuilder.build_error_response(
+                    f"Workout {i}: Missing required field 'folder_id'",
+                    error_type="validation_error",
+                )
+            if "name" not in workout_data:
+                return ResponseBuilder.build_error_response(
+                    f"Workout {i}: Missing required field 'name'",
+                    error_type="validation_error",
+                )
+
+        async with ICUClient(config) as client:
+            created = await client.bulk_create_workouts(workouts_data)
+
+            return ResponseBuilder.build_response(
+                data={"workouts": [_workout_to_dict(w) for w in created]},
+                query_type="bulk_create_workouts",
+                metadata={
+                    "message": f"Successfully created {len(created)} workouts",
+                    "count": len(created),
+                },
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def get_workout_tags(
+    ctx: Context | None = None,
+) -> str:
+    """List all workout tags used in the athlete's library.
+
+    Returns:
+        JSON string with list of tag strings
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            tags = await client.get_workout_tags()
+
+            return ResponseBuilder.build_response(
+                data={"tags": tags, "count": len(tags)},
+                query_type="workout_tags",
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def duplicate_workouts(
+    workout_ids: Annotated[str, "JSON array of workout IDs to duplicate (e.g., '[101, 102]')"],
+    num_copies: Annotated[int, "Number of copies to create"] = 1,
+    weeks_between: Annotated[int, "Number of weeks between each copy"] = 1,
+    ctx: Context | None = None,
+) -> str:
+    """Duplicate workouts on a training plan.
+
+    Creates copies of the specified workouts, spaced the given number of weeks apart.
+    Useful for repeating blocks in a training plan.
+
+    Returns:
+        JSON string with created workout copies
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        try:
+            ids_parsed = json.loads(workout_ids)
+        except json.JSONDecodeError as e:
+            return ResponseBuilder.build_error_response(
+                f"Invalid JSON format: {str(e)}", error_type="validation_error"
+            )
+
+        if not isinstance(ids_parsed, list):
+            return ResponseBuilder.build_error_response(
+                "workout_ids must be a JSON array", error_type="validation_error"
+            )
+
+        ids_list: list[int] = ids_parsed  # type: ignore[assignment]
+
+        async with ICUClient(config) as client:
+            created = await client.duplicate_workouts(ids_list, num_copies, weeks_between)
+
+            return ResponseBuilder.build_response(
+                data={"workouts": [_workout_to_dict(w) for w in created]},
+                query_type="duplicate_workouts",
+                metadata={
+                    "message": f"Successfully duplicated {len(ids_list)} workouts x{num_copies} copies",
+                    "count": len(created),
+                },
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def import_workout(
+    folder_id: Annotated[int, "Folder ID to import the workout into"],
+    file_contents_base64: Annotated[str, "Base64-encoded file content (.zwo, .mrc, .erg, or .fit)"],
+    filename: Annotated[str, "Original filename with extension (e.g., 'threshold.zwo')"],
+    activity_type: Annotated[str | None, "Activity type (e.g., Ride, Run, Swim)"] = None,
+    ctx: Context | None = None,
+) -> str:
+    """Import a workout file into a folder.
+
+    Supports .zwo (Zwift), .mrc, .erg (ERG/MRC format), and .fit file formats.
+    Provide the file contents as a base64-encoded string.
+
+    Returns:
+        JSON string with imported workout data
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        file_bytes = base64.b64decode(file_contents_base64)
+    except Exception:
+        return ResponseBuilder.build_error_response(
+            "Invalid base64 encoding in file_contents_base64", error_type="validation_error"
+        )
+
+    try:
+        async with ICUClient(config) as client:
+            workout = await client.import_workout(
+                folder_id, file_bytes, filename, activity_type=activity_type
+            )
+
+            return ResponseBuilder.build_response(
+                data=_workout_to_dict(workout),
+                query_type="import_workout",
+                metadata={"message": f"Successfully imported workout from {filename}"},
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def export_workout(
+    workout_id: Annotated[int, "Workout ID to export"],
+    format: Annotated[str, "Export format: zwo, mrc, erg, or fit"],
+    ctx: Context | None = None,
+) -> str:
+    """Export a workout to a file format.
+
+    Converts a workout to .zwo (Zwift), .mrc, .erg, or .fit format.
+    Returns the file content as a base64-encoded string.
+
+    Returns:
+        JSON string with filename and base64-encoded file content
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    valid_formats = ["zwo", "mrc", "erg", "fit"]
+    fmt = format.lower().lstrip(".")
+    if fmt not in valid_formats:
+        return ResponseBuilder.build_error_response(
+            f"Invalid format. Must be one of: {', '.join(valid_formats)}",
+            error_type="validation_error",
+        )
+
+    try:
+        async with ICUClient(config) as client:
+            workout = await client.get_workout(workout_id)
+            workout_dict = _workout_to_dict(workout)
+            file_bytes = await client.download_workout(workout_dict, fmt)
+
+            encoded = base64.b64encode(file_bytes).decode("utf-8")
+            workout_name = (workout.name or str(workout_id)).replace(" ", "_")
+            filename = f"{workout_name}.{fmt}"
+
+            return ResponseBuilder.build_response(
+                data={
+                    "workout_id": workout_id,
+                    "filename": filename,
+                    "format": fmt,
+                    "file_contents_base64": encoded,
+                    "size_bytes": len(file_bytes),
+                },
+                query_type="export_workout",
+                metadata={"message": f"Successfully exported workout {workout_id} as {filename}"},
+            )
+
+    except ICUAPIError as e:
+        return ResponseBuilder.build_error_response(e.message, error_type="api_error")
+    except Exception as e:
+        return ResponseBuilder.build_error_response(
+            f"Unexpected error: {str(e)}", error_type="internal_error"
+        )
+
+
+async def download_all_workouts(
+    ctx: Context | None = None,
+) -> str:
+    """Download all workouts in the library as a ZIP archive.
+
+    Returns the ZIP file as a base64-encoded string. Useful for backup
+    or transferring workouts to another platform.
+
+    Returns:
+        JSON string with base64-encoded ZIP file
+    """
+    assert ctx is not None
+    config: ICUConfig = ctx.get_state("config")
+
+    try:
+        async with ICUClient(config) as client:
+            zip_bytes = await client.download_workouts_zip()
+
+            encoded = base64.b64encode(zip_bytes).decode("utf-8")
+
+            return ResponseBuilder.build_response(
+                data={
+                    "filename": "workouts.zip",
+                    "file_contents_base64": encoded,
+                    "size_bytes": len(zip_bytes),
+                },
+                query_type="download_all_workouts",
+                metadata={"message": "Successfully downloaded all workouts as ZIP"},
             )
 
     except ICUAPIError as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,15 +110,18 @@ def mock_event_data():
 
 @pytest.fixture
 def mock_power_curve_data():
-    """Sample power curve data for testing."""
+    """Sample power curve data matching DataCurveSetPowerCurve API response."""
     return {
-        "name": "Power Curve",
-        "type": "power",
-        "athlete_id": "i123456",
-        "data": [
-            {"secs": 5, "watts": 800, "date": "2025-10-01"},
-            {"secs": 60, "watts": 400, "date": "2025-10-05"},
-            {"secs": 300, "watts": 300, "date": "2025-10-08"},
-            {"secs": 1200, "watts": 250, "date": "2025-10-12"},
+        "list": [
+            {
+                "id": "1y",
+                "label": "past year",
+                "start_date_local": "2025-03-24",
+                "end_date_local": "2026-03-24",
+                "secs": [5, 60, 300, 1200, 3600],
+                "values": [800, 400, 300, 250, 200],
+                "activity_id": ["act1", "act2", "act3", "act4", "act5"],
+            }
         ],
+        "activities": {},
     }

--- a/tests/test_athlete_tools.py
+++ b/tests/test_athlete_tools.py
@@ -82,7 +82,9 @@ class TestGetFitnessSummary:
         mock_ctx = MagicMock()
         mock_ctx.get_state.return_value = mock_config
 
-        wellness_high_ramp = [{"id": "2026-03-24", "ctl": 50.0, "atl": 35.0, "tsb": 15.0, "rampRate": 10.0}]
+        wellness_high_ramp = [
+            {"id": "2026-03-24", "ctl": 50.0, "atl": 35.0, "tsb": 15.0, "rampRate": 10.0}
+        ]
 
         respx_mock.get("/athlete/i123456").mock(return_value=Response(200, json=mock_athlete_data))
         respx_mock.get("/athlete/i123456/wellness").mock(

--- a/tests/test_athlete_tools.py
+++ b/tests/test_athlete_tools.py
@@ -1,10 +1,21 @@
 """Tests for athlete tools."""
 
+import json
 from unittest.mock import MagicMock
 
 from httpx import Response
 
 from intervals_icu_mcp.tools.athlete import get_athlete_profile, get_fitness_summary
+
+WELLNESS_WITH_FITNESS = [
+    {
+        "id": "2026-03-24",
+        "ctl": 50.0,
+        "atl": 35.0,
+        "tsb": 15.0,
+        "rampRate": 3.5,
+    }
+]
 
 
 class TestGetAthleteProfile:
@@ -17,17 +28,15 @@ class TestGetAthleteProfile:
         mock_athlete_data,
     ):
         """Test successful athlete profile retrieval."""
-        # Create mock context with config
         mock_ctx = MagicMock()
         mock_ctx.get_state.return_value = mock_config
 
-        # Mock the API endpoint
         respx_mock.get("/athlete/i123456").mock(return_value=Response(200, json=mock_athlete_data))
+        respx_mock.get("/athlete/i123456/wellness").mock(
+            return_value=Response(200, json=WELLNESS_WITH_FITNESS)
+        )
 
         result = await get_athlete_profile(ctx=mock_ctx)
-
-        # Check for JSON response with expected fields
-        import json
 
         response = json.loads(result)
         assert "data" in response
@@ -48,17 +57,15 @@ class TestGetFitnessSummary:
         mock_athlete_data,
     ):
         """Test successful fitness summary retrieval."""
-        # Create mock context with config
         mock_ctx = MagicMock()
         mock_ctx.get_state.return_value = mock_config
 
-        # Mock the API endpoint
         respx_mock.get("/athlete/i123456").mock(return_value=Response(200, json=mock_athlete_data))
+        respx_mock.get("/athlete/i123456/wellness").mock(
+            return_value=Response(200, json=WELLNESS_WITH_FITNESS)
+        )
 
         result = await get_fitness_summary(ctx=mock_ctx)
-
-        # Check for JSON response with expected fields
-        import json
 
         response = json.loads(result)
         assert "data" in response
@@ -72,20 +79,17 @@ class TestGetFitnessSummary:
         mock_athlete_data,
     ):
         """Test fitness summary with high ramp rate warning."""
-        # Create mock context with config
         mock_ctx = MagicMock()
         mock_ctx.get_state.return_value = mock_config
 
-        # Modify athlete data to have high ramp rate
-        athlete_data = mock_athlete_data.copy()
-        athlete_data["ramp_rate"] = 10.0
+        wellness_high_ramp = [{"id": "2026-03-24", "ctl": 50.0, "atl": 35.0, "tsb": 15.0, "rampRate": 10.0}]
 
-        respx_mock.get("/athlete/i123456").mock(return_value=Response(200, json=athlete_data))
+        respx_mock.get("/athlete/i123456").mock(return_value=Response(200, json=mock_athlete_data))
+        respx_mock.get("/athlete/i123456/wellness").mock(
+            return_value=Response(200, json=wellness_high_ramp)
+        )
 
         result = await get_fitness_summary(ctx=mock_ctx)
-
-        # Check for JSON response with ramp rate analysis
-        import json
 
         response = json.loads(result)
         assert "analysis" in response

--- a/tests/test_event_management.py
+++ b/tests/test_event_management.py
@@ -1,0 +1,312 @@
+"""Tests for event management tools."""
+
+import json
+from unittest.mock import MagicMock
+
+from httpx import Response
+
+from intervals_icu_mcp.tools.event_management import (
+    bulk_create_events,
+    create_event,
+    duplicate_event,
+    update_event,
+)
+
+
+def make_event_response(**kwargs):
+    base = {
+        "id": 1001,
+        "start_date_local": "2026-04-01",
+        "category": "WORKOUT",
+        "name": "Test Workout",
+    }
+    base.update(kwargs)
+    return base
+
+
+class TestCreateEvent:
+    async def test_create_basic_event(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        event_data = make_event_response()
+        respx_mock.post("/athlete/i123456/events").mock(return_value=Response(200, json=event_data))
+
+        result = await create_event(
+            start_date="2026-04-01",
+            name="Test Workout",
+            category="WORKOUT",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["id"] == 1001
+        assert response["data"]["name"] == "Test Workout"
+        assert response["data"]["category"] == "WORKOUT"
+
+    async def test_create_event_with_workout_doc(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        event_data = make_event_response(
+            workout_doc={"steps": [{"duration": 300, "power": {"value": 250, "units": "W"}}]}
+        )
+        respx_mock.post("/athlete/i123456/events").mock(return_value=Response(200, json=event_data))
+
+        workout_doc_json = json.dumps(
+            {"steps": [{"duration": 300, "power": {"value": 250, "units": "W"}}]}
+        )
+
+        result = await create_event(
+            start_date="2026-04-01",
+            name="Structured Workout",
+            category="WORKOUT",
+            workout_doc=workout_doc_json,
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert "workout_doc" in response["data"]
+        assert response["data"]["workout_doc"]["steps"][0]["duration"] == 300
+
+    async def test_create_event_with_tags(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        event_data = make_event_response(tags=["intervals", "threshold"])
+        respx_mock.post("/athlete/i123456/events").mock(return_value=Response(200, json=event_data))
+
+        result = await create_event(
+            start_date="2026-04-01",
+            name="Threshold Work",
+            category="WORKOUT",
+            tags="intervals,threshold",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["tags"] == ["intervals", "threshold"]
+
+    async def test_create_event_invalid_category(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await create_event(
+            start_date="2026-04-01",
+            name="Bad Event",
+            category="INVALID",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "error" in response
+
+    async def test_create_event_invalid_date(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await create_event(
+            start_date="not-a-date",
+            name="Test",
+            category="WORKOUT",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "error" in response
+
+    async def test_create_event_all_14_categories(self, mock_config, respx_mock):
+        """Verify all 14 event categories are accepted."""
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        categories = [
+            "WORKOUT",
+            "RACE_A",
+            "RACE_B",
+            "RACE_C",
+            "NOTE",
+            "PLAN",
+            "HOLIDAY",
+            "SICK",
+            "INJURED",
+            "SET_EFTP",
+            "FITNESS_DAYS",
+            "SEASON_START",
+            "TARGET",
+            "SET_FITNESS",
+        ]
+
+        for cat in categories:
+            event_data = make_event_response(category=cat)
+            respx_mock.post("/athlete/i123456/events").mock(
+                return_value=Response(200, json=event_data)
+            )
+            result = await create_event(
+                start_date="2026-04-01", name=f"Test {cat}", category=cat, ctx=mock_ctx
+            )
+            response = json.loads(result)
+            assert "data" in response, f"Category {cat} should be valid but got error"
+
+    async def test_create_event_invalid_workout_doc_json(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await create_event(
+            start_date="2026-04-01",
+            name="Bad Workout",
+            category="WORKOUT",
+            workout_doc="{invalid json",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "error" in response
+
+    async def test_create_event_with_indoor_and_target(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        event_data = make_event_response(indoor=True, target="POWER")
+        respx_mock.post("/athlete/i123456/events").mock(return_value=Response(200, json=event_data))
+
+        result = await create_event(
+            start_date="2026-04-01",
+            name="Indoor Ride",
+            category="WORKOUT",
+            indoor=True,
+            target="POWER",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["indoor"] is True
+        assert response["data"]["target"] == "POWER"
+
+
+class TestUpdateEvent:
+    async def test_update_event_basic(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        event_data = make_event_response(name="Updated Workout")
+        respx_mock.put("/athlete/i123456/events/1001").mock(
+            return_value=Response(200, json=event_data)
+        )
+
+        result = await update_event(event_id=1001, name="Updated Workout", ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["name"] == "Updated Workout"
+
+    async def test_update_event_with_workout_doc(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        new_doc = {"steps": [{"duration": 600}]}
+        event_data = make_event_response(workout_doc=new_doc)
+        respx_mock.put("/athlete/i123456/events/1001").mock(
+            return_value=Response(200, json=event_data)
+        )
+
+        result = await update_event(
+            event_id=1001,
+            workout_doc=json.dumps(new_doc),
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["workout_doc"]["steps"][0]["duration"] == 600
+
+    async def test_update_event_no_fields_error(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await update_event(event_id=1001, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "error" in response
+
+
+class TestBulkCreateEvents:
+    async def test_bulk_create_valid(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        events_response = [
+            make_event_response(id=1001, name="Ride 1"),
+            make_event_response(id=1002, name="Run 1"),
+        ]
+        respx_mock.post("/athlete/i123456/events/bulk").mock(
+            return_value=Response(200, json=events_response)
+        )
+
+        events_json = json.dumps(
+            [
+                {"start_date_local": "2026-04-01", "name": "Ride 1", "category": "WORKOUT"},
+                {"start_date_local": "2026-04-02", "name": "Run 1", "category": "WORKOUT"},
+            ]
+        )
+
+        result = await bulk_create_events(events=events_json, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["metadata"]["count"] == 2
+
+    async def test_bulk_create_accepts_new_categories(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        events_response = [make_event_response(category="RACE_A")]
+        respx_mock.post("/athlete/i123456/events/bulk").mock(
+            return_value=Response(200, json=events_response)
+        )
+
+        events_json = json.dumps(
+            [{"start_date_local": "2026-05-01", "name": "A Race", "category": "RACE_A"}]
+        )
+
+        result = await bulk_create_events(events=events_json, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+
+    async def test_bulk_create_invalid_json(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await bulk_create_events(events="not json", ctx=mock_ctx)
+        response = json.loads(result)
+        assert "error" in response
+
+
+class TestDuplicateEvent:
+    async def test_duplicate_event(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        event_data = make_event_response(start_date_local="2026-04-08")
+        respx_mock.post("/athlete/i123456/events/1001/duplicate").mock(
+            return_value=Response(200, json=event_data)
+        )
+
+        result = await duplicate_event(event_id=1001, new_date="2026-04-08", ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["original_event_id"] == 1001
+
+    async def test_duplicate_event_invalid_date(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await duplicate_event(event_id=1001, new_date="bad-date", ctx=mock_ctx)
+        response = json.loads(result)
+        assert "error" in response

--- a/tests/test_folder_tools.py
+++ b/tests/test_folder_tools.py
@@ -1,0 +1,197 @@
+"""Tests for folder management tools."""
+
+import json
+from unittest.mock import MagicMock
+
+from httpx import Response
+
+from intervals_icu_mcp.tools.folder_management import (
+    create_folder,
+    delete_folder,
+    get_folder_sharing,
+    update_folder,
+    update_folder_sharing,
+    update_plan_workouts,
+)
+
+
+def make_folder_response(**kwargs):
+    base = {
+        "id": 10,
+        "name": "Test Folder",
+        "type": "FOLDER",
+    }
+    base.update(kwargs)
+    return base
+
+
+class TestCreateFolder:
+    async def test_create_folder_basic(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        folder_data = make_folder_response()
+        respx_mock.post("/athlete/i123456/folders").mock(
+            return_value=Response(200, json=folder_data)
+        )
+
+        result = await create_folder(name="Test Folder", ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["name"] == "Test Folder"
+        assert response["data"]["id"] == 10
+
+    async def test_create_training_plan(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        folder_data = make_folder_response(
+            name="16-Week Base Build",
+            type="PLAN",
+            duration_weeks=16,
+            start_date_local="2026-05-01",
+        )
+        respx_mock.post("/athlete/i123456/folders").mock(
+            return_value=Response(200, json=folder_data)
+        )
+
+        result = await create_folder(
+            name="16-Week Base Build",
+            folder_type="PLAN",
+            start_date="2026-05-01",
+            rollout_weeks=16,
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["type"] == "PLAN"
+
+    async def test_create_folder_invalid_type(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await create_folder(name="Bad", folder_type="INVALID", ctx=mock_ctx)
+        response = json.loads(result)
+        assert "error" in response
+
+    async def test_create_folder_invalid_visibility(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await create_folder(name="Bad", visibility="HIDDEN", ctx=mock_ctx)
+        response = json.loads(result)
+        assert "error" in response
+
+
+class TestUpdateFolder:
+    async def test_update_folder_name(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        folder_data = make_folder_response(name="Renamed Folder")
+        respx_mock.put("/athlete/i123456/folders/10").mock(
+            return_value=Response(200, json=folder_data)
+        )
+
+        result = await update_folder(folder_id=10, name="Renamed Folder", ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["name"] == "Renamed Folder"
+
+    async def test_update_folder_no_fields_error(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await update_folder(folder_id=10, ctx=mock_ctx)
+        response = json.loads(result)
+        assert "error" in response
+
+
+class TestDeleteFolder:
+    async def test_delete_folder_success(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        respx_mock.delete("/athlete/i123456/folders/10").mock(return_value=Response(204))
+
+        result = await delete_folder(folder_id=10, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["deleted"] is True
+
+
+class TestUpdatePlanWorkouts:
+    async def test_update_plan_workouts(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        workouts = [{"id": 501, "name": "W1", "folder_id": 10}]
+        respx_mock.put("/athlete/i123456/folders/10/workouts").mock(
+            return_value=Response(200, json=workouts)
+        )
+
+        result = await update_plan_workouts(folder_id=10, hide_from_athlete=True, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["updated_count"] == 1
+
+    async def test_update_plan_workouts_no_fields_error(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await update_plan_workouts(folder_id=10, ctx=mock_ctx)
+        response = json.loads(result)
+        assert "error" in response
+
+
+class TestFolderSharing:
+    async def test_get_folder_sharing(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        shared = [{"id": "i999", "name": "Buddy", "canEdit": False, "email": "buddy@example.com"}]
+        respx_mock.get("/athlete/i123456/folders/10/shared-with").mock(
+            return_value=Response(200, json=shared)
+        )
+
+        result = await get_folder_sharing(folder_id=10, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["count"] == 1
+        assert response["data"]["shared_with"][0]["id"] == "i999"
+
+    async def test_update_folder_sharing(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        updated = [{"id": "i999", "name": "Buddy", "canEdit": True}]
+        respx_mock.put("/athlete/i123456/folders/10/shared-with").mock(
+            return_value=Response(200, json=updated)
+        )
+
+        athletes_json = json.dumps([{"id": "i999", "canEdit": True}])
+        result = await update_folder_sharing(folder_id=10, athletes=athletes_json, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["count"] == 1
+
+    async def test_update_folder_sharing_empty_removes_all(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        respx_mock.put("/athlete/i123456/folders/10/shared-with").mock(
+            return_value=Response(200, json=[])
+        )
+
+        result = await update_folder_sharing(folder_id=10, athletes="[]", ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["count"] == 0

--- a/tests/test_training_plan_tools.py
+++ b/tests/test_training_plan_tools.py
@@ -1,0 +1,112 @@
+"""Tests for training plan management tools."""
+
+import json
+from unittest.mock import MagicMock
+
+from httpx import Response
+
+from intervals_icu_mcp.tools.training_plan import (
+    apply_plan_changes,
+    get_training_plan,
+    set_training_plan,
+)
+
+
+def make_plan_response(**kwargs):
+    base = {
+        "id": "i123456",
+        "training_plan_id": 42,
+        "training_plan_start_date": "2026-05-01",
+        "training_plan_alias": "My Base Build",
+        "training_plan": {
+            "id": 42,
+            "name": "16-Week Base Build",
+            "duration_weeks": 16,
+            "num_workouts": 64,
+        },
+    }
+    base.update(kwargs)
+    return base
+
+
+class TestGetTrainingPlan:
+    async def test_get_training_plan_with_plan(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        plan_data = make_plan_response()
+        respx_mock.get("/athlete/i123456/training-plan").mock(
+            return_value=Response(200, json=plan_data)
+        )
+
+        result = await get_training_plan(ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["training_plan"]["training_plan_id"] == 42
+        assert response["data"]["training_plan"]["start_date"] == "2026-05-01"
+
+    async def test_get_training_plan_none_assigned(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        respx_mock.get("/athlete/i123456/training-plan").mock(
+            return_value=Response(200, json={"id": "i123456"})
+        )
+
+        result = await get_training_plan(ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["training_plan"] is None
+
+
+class TestSetTrainingPlan:
+    async def test_set_training_plan(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        plan_data = make_plan_response()
+        respx_mock.put("/athlete/i123456/training-plan").mock(
+            return_value=Response(200, json=plan_data)
+        )
+
+        result = await set_training_plan(
+            training_plan_id=42,
+            start_date="2026-05-01",
+            alias="My Base Build",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["training_plan"]["training_plan_id"] == 42
+
+    async def test_set_training_plan_invalid_date(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await set_training_plan(
+            training_plan_id=42,
+            start_date="not-a-date",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "error" in response
+
+
+class TestApplyPlanChanges:
+    async def test_apply_plan_changes(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        respx_mock.put("/athlete/i123456/apply-plan-changes").mock(
+            return_value=Response(200, json={"applied": True, "count": 12})
+        )
+
+        result = await apply_plan_changes(ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["applied"] is True

--- a/tests/test_workout_tools.py
+++ b/tests/test_workout_tools.py
@@ -1,0 +1,253 @@
+"""Tests for workout library tools."""
+
+import json
+from unittest.mock import MagicMock
+
+from httpx import Response
+
+from intervals_icu_mcp.tools.workout_library import (
+    bulk_create_workouts,
+    create_workout,
+    delete_workout,
+    duplicate_workouts,
+    get_workout,
+    get_workout_tags,
+    update_workout,
+)
+
+
+def make_workout_response(**kwargs):
+    base = {
+        "id": 501,
+        "name": "Test Workout",
+        "folder_id": 10,
+        "type": "Ride",
+        "moving_time": 3600,
+    }
+    base.update(kwargs)
+    return base
+
+
+class TestGetWorkout:
+    async def test_get_workout_success(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        workout_data = make_workout_response(workout_doc={"steps": [{"duration": 300}]})
+        respx_mock.get("/athlete/i123456/workouts/501").mock(
+            return_value=Response(200, json=workout_data)
+        )
+
+        result = await get_workout(workout_id=501, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["id"] == 501
+        assert response["data"]["workout_doc"]["steps"][0]["duration"] == 300
+
+
+class TestCreateWorkout:
+    async def test_create_workout_basic(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        workout_data = make_workout_response()
+        respx_mock.post("/athlete/i123456/workouts").mock(
+            return_value=Response(200, json=workout_data)
+        )
+
+        result = await create_workout(folder_id=10, name="Test Workout", ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["name"] == "Test Workout"
+        assert response["data"]["folder_id"] == 10
+
+    async def test_create_workout_with_workout_doc(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        doc = {"steps": [{"duration": 600, "power": {"value": 300, "units": "W"}}]}
+        workout_data = make_workout_response(workout_doc=doc)
+        respx_mock.post("/athlete/i123456/workouts").mock(
+            return_value=Response(200, json=workout_data)
+        )
+
+        result = await create_workout(
+            folder_id=10,
+            name="FTP Test",
+            workout_doc=json.dumps(doc),
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert "workout_doc" in response["data"]
+
+    async def test_create_workout_invalid_workout_doc(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await create_workout(
+            folder_id=10,
+            name="Bad",
+            workout_doc="{bad json",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "error" in response
+
+    async def test_create_workout_with_tags(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        workout_data = make_workout_response(tags=["intervals", "vo2max"])
+        respx_mock.post("/athlete/i123456/workouts").mock(
+            return_value=Response(200, json=workout_data)
+        )
+
+        result = await create_workout(
+            folder_id=10,
+            name="VO2max",
+            tags="intervals,vo2max",
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["tags"] == ["intervals", "vo2max"]
+
+
+class TestUpdateWorkout:
+    async def test_update_workout_name(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        workout_data = make_workout_response(name="Updated Name")
+        respx_mock.put("/athlete/i123456/workouts/501").mock(
+            return_value=Response(200, json=workout_data)
+        )
+
+        result = await update_workout(workout_id=501, name="Updated Name", ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["name"] == "Updated Name"
+
+    async def test_update_workout_no_fields_error(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await update_workout(workout_id=501, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "error" in response
+
+
+class TestDeleteWorkout:
+    async def test_delete_workout_success(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        respx_mock.delete("/athlete/i123456/workouts/501").mock(return_value=Response(204))
+
+        result = await delete_workout(workout_id=501, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["deleted"] is True
+
+
+class TestBulkCreateWorkouts:
+    async def test_bulk_create_valid(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        workouts_response = [
+            make_workout_response(id=501, name="Workout 1"),
+            make_workout_response(id=502, name="Workout 2"),
+        ]
+        respx_mock.post("/athlete/i123456/workouts/bulk").mock(
+            return_value=Response(200, json=workouts_response)
+        )
+
+        workouts_json = json.dumps(
+            [
+                {"folder_id": 10, "name": "Workout 1"},
+                {"folder_id": 10, "name": "Workout 2"},
+            ]
+        )
+
+        result = await bulk_create_workouts(workouts=workouts_json, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["metadata"]["count"] == 2
+
+    async def test_bulk_create_missing_folder_id(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        workouts_json = json.dumps([{"name": "Missing folder_id"}])
+        result = await bulk_create_workouts(workouts=workouts_json, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "error" in response
+
+    async def test_bulk_create_missing_name(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        workouts_json = json.dumps([{"folder_id": 10}])
+        result = await bulk_create_workouts(workouts=workouts_json, ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "error" in response
+
+
+class TestGetWorkoutTags:
+    async def test_get_workout_tags(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        respx_mock.get("/athlete/i123456/workout-tags").mock(
+            return_value=Response(200, json=["intervals", "endurance", "recovery"])
+        )
+
+        result = await get_workout_tags(ctx=mock_ctx)
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["count"] == 3
+        assert "intervals" in response["data"]["tags"]
+
+
+class TestDuplicateWorkouts:
+    async def test_duplicate_workouts(self, mock_config, respx_mock):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        created = [make_workout_response(id=601), make_workout_response(id=602)]
+        respx_mock.post("/athlete/i123456/duplicate-workouts").mock(
+            return_value=Response(200, json=created)
+        )
+
+        result = await duplicate_workouts(
+            workout_ids="[501]",
+            num_copies=2,
+            weeks_between=1,
+            ctx=mock_ctx,
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["metadata"]["count"] == 2
+
+    async def test_duplicate_workouts_invalid_json(self, mock_config):
+        mock_ctx = MagicMock()
+        mock_ctx.get_state.return_value = mock_config
+
+        result = await duplicate_workouts(workout_ids="not-json", ctx=mock_ctx)
+        response = json.loads(result)
+        assert "error" in response


### PR DESCRIPTION
                                                                                                         
  ## Summary                                                                                             
                                                                                                         
  This PR fixes several bugs in the existing implementation and significantly                            
  expands the tool surface to cover more of the Intervals.icu API.
                                                                                                         
  ### Bug fixes                                                                                       
                                                                                                         
  - **Middleware bypass** (`gear.py`, `sport_settings.py`): All 11 functions were                        
    calling `load_config()`/`validate_credentials()` directly instead of reading
    config from context state, bypassing the `ConfigMiddleware` entirely.                                
  - **Activity streams** (`client.py`, `models.py`): The streams endpoint returns                        
    an array of `{type, name, data}` objects, not a dict — `ActivityStreams(**response.json())`          
    threw a `TypeError`. Also adds `raw_watts` support since the API renames                             
    `watts` → `raw_watts` when no type filter is specified.                                              
  - **Power curves** (`client.py`, `performance.py`): Fixed endpoint path (added                         
    `.json`), corrected `curves` param construction, and added `sport_type` param.                       
  - **Model defaults** (`models.py`): Fixed 5 instances of                                               
    `default_factory=list[SomeType]` which is not callable in Python 3.11+.                              
  - **Fitness metrics** (`athlete.py`): CTL/ATL/TSB are not returned on the                              
    athlete profile endpoint — fixed to read from wellness records instead.                              
  - **Event date format** (`events.py`, `event_management.py`): Slice                                 
    `start_date_local` to handle both date and datetime strings from the API;                            
    append `T00:00:00` on create/bulk_create so the API accepts the value.                               
  - **Calendar events missing ID** (`events.py`): Event items were missing their                         
    `id` field, making update/delete impossible after a calendar query.                                  
  - **Null tags coercion** (`models.py`): Added `field_validator` to coerce null                         
    `tags` from API responses to `[]`, preventing Pydantic validation errors on                          
    existing data.                                                                                       
  - **Recent activities** (`activities.py`): Raised default activity cap from 100                        
    to 500 and exposed `oldest`/`newest` date filter params.                                             
                                                                                                         
  ### New tools (40 → 67)                                                                                
                                                                                                         
  - **Workout library**: full CRUD (`create_workout`, `get_workout`,                                     
    `update_workout`, `delete_workout`), tags, bulk ops, duplication,
    and file import/export (`.zwo`, `.mrc`, `.erg`, `.fit` via base64).                                  
  - **Folder management**: create/update/delete folders and training plans,                              
    batch-update plan workouts, folder sharing with per-athlete `canEdit` control.                       
  - **Training plans**: assign plans to athletes, apply plan changes to the calendar.                    
  - **Enhanced events**: `create_event`/`update_event` now support `workout_doc`,                        
    tags, indoor flag, target, sub_type, color, and all 14 event categories (was 4).                     
                                                                                                         
  ### Improved LLM guidance                                                                              
                                                                                                      
  - Expanded `description` param docs with full Intervals.icu workout text syntax                        
    (zones, FTP%, repeats) so the model can author structured workouts correctly.                     
  - Updated tag param descriptions to discourage auto-tagging (tags render as                            
    visible hashtags in the UI and should only be added when explicitly requested).   