### PR TITLE
fix: use activity-*-curves endpoints to resolve empty power/hr/pace curve responses

### DIFF
--- a/INTERVALS_FORMAT_SPEC.md
+++ b/INTERVALS_FORMAT_SPEC.md
@@ -1,0 +1,275 @@
+# Intervals.icu Workout Format Specification
+Reference for automated FinalSurge → Intervals.icu translation
+
+## Core Syntax Rules
+
+### Step Format
+```
+- [duration OR distance] [intensity] [optional_cadence]
+```
+
+**MUST start with `-` (dash + space)**
+
+Examples:
+```
+- 30m z2 pace
+- 15s z5 pace
+- 1m45s z2 pace
+- 10m 75% 90rpm
+```
+
+## Duration Formats
+
+| Format | Example | Notes |
+|--------|---------|-------|
+| Minutes | `30m`, `5m` | **`m` = minutes, NOT meters** |
+| Seconds | `15s`, `90s` | |
+| Combined | `1m30s`, `1h2m30s` | |
+| Hours | `1h`, `2h30m` | |
+| Shorthand | `5'`, `30"`, `1'30"` | Optional, prefer full format |
+
+**Critical**: Never use `m` for meters. Use `km` or `mi` for distance.
+
+## Intensity Formats
+
+### Running (Pace-based)
+```
+z1 pace    # Recovery (70-75% of pace)
+z2 pace    # Easy (76-80%)
+z3 pace    # Tempo (81-88%)
+z4 pace    # Threshold/HMP (89-95%)
+z5 pace    # VO2 Max/Strides (96-105%)
+z6 pace    # Sprint (>105%)
+```
+
+Alternative formats:
+```
+78-82% pace      # Percentage range
+90% pace         # Single percentage
+```
+
+### Heart Rate
+```
+70% HR           # Percentage of max
+75-80% HR        # Range
+95% LTHR         # Percentage of threshold
+Z2 HR            # Zone-based
+```
+
+### Cycling (Power)
+```
+75%              # Percentage of FTP
+200-240w         # Watts range
+Z2               # Zone
+ramp 50%-75%     # Gradual increase
+```
+
+## Interval/Repeat Syntax
+
+### Two Valid Forms
+
+**Form 1: Section Header**
+```
+Main Set 6x
+- 15s z5 pace
+- 1m45s z2 pace
+```
+
+**Form 2: Standalone Line** (RECOMMENDED for clarity)
+```
+6x
+- 15s z5 pace
+- 1m45s z2 pace
+```
+
+### Required Formatting Around Repeats
+
+**CRITICAL**: Blank lines MUST surround repeat blocks
+
+```
+- 18m z2 pace
+                   ← BLANK LINE REQUIRED
+6x
+- 15s z5 pace
+- 1m45s z2 pace
+                   ← BLANK LINE REQUIRED (if more steps follow)
+- 5m z2 pace
+```
+
+### Nested Repeats: NOT SUPPORTED
+
+❌ **INVALID**:
+```
+3x
+- 10m z3 pace
+- 2x                 ← Nested repeat
+  - 30s z5 pace
+  - 30s z2 pace
+```
+
+✅ **VALID** (flatten the structure):
+```
+3x
+- 10m z3 pace
+- 30s z5 pace
+- 30s z2 pace
+- 30s z5 pace
+- 30s z2 pace
+```
+
+## Section Headers
+
+Lines without `-` are treated as headers/labels:
+```
+Warmup
+- 10m z2 pace
+
+Main Set 6x
+- 15s z5 pace
+- 1m45s z2 pace
+
+Cooldown
+- 5m z2 pace
+```
+
+## Text Prompts/Cues
+
+**Basic cue**: Text before duration/intensity
+```
+- Recovery 30s z1 pace     # Cue displays as "Recovery"
+```
+
+**Timed prompts**: Use `time^message <!> step`
+```
+- First cue 30^Second cue <!> 10m ramp 50-75%
+```
+
+## Complete Workout Structure Examples
+
+### Simple Run
+```
+- 30m z2 pace
+```
+
+### Run with Strides
+```
+- 18m z2 pace
+
+7x
+- 17s z5 pace
+- 1m45s z2 pace
+```
+
+### Structured Interval Workout
+```
+Warmup
+- 15m z2 pace
+
+Main Set 2x
+- 10m z4 pace
+- 5m z2 pace
+
+Cooldown
+- 5m z2 pace
+```
+
+## Common FinalSurge → Intervals.icu Mappings
+
+### Intensity Terms
+| FinalSurge | Intervals.icu |
+|------------|---------------|
+| "easy", "easy jog" | `z2 pace` |
+| "recovery" | `z1 pace` |
+| "tempo" | `z3 pace` |
+| "threshold", "@threshold" | `z4 pace` |
+| "HMP", "@HMP" | `z4 pace` |
+| "stride", "strides", "fast" | `z5 pace` |
+| "sprint" | `z6 pace` |
+
+### Duration Patterns
+| Pattern | Resolution | Example |
+|---------|------------|---------|
+| "15-20s" | Midpoint | `17s` |
+| "6-8x" | Midpoint rounded down | `7x` |
+| "Full recovery" | Calculate from total time | `1m45s` |
+
+## Formatting Checklist
+
+- [ ] All steps start with `-` (dash space)
+- [ ] Blank line before repeat block
+- [ ] Standalone `Nx` line (not inline)
+- [ ] Blank line after repeat block (if more steps follow)
+- [ ] No nested repeats
+- [ ] Duration uses `m` for minutes (not meters)
+- [ ] Intensity includes unit (`pace`, `HR`, `%`, etc.)
+- [ ] Total duration matches expected workout length
+
+## Error Prevention
+
+### Common Mistakes
+❌ Missing dash: `30m z2 pace`
+✅ Correct: `- 30m z2 pace`
+
+❌ No blank line: 
+```
+- 18m z2 pace
+6x
+```
+✅ Correct:
+```
+- 18m z2 pace
+
+6x
+```
+
+❌ Inline repeat: `- 6x 15s z5 pace`
+✅ Correct:
+```
+6x
+- 15s z5 pace
+```
+
+❌ Nested repeat:
+```
+2x
+- 10m z3
+- 3x
+  - 30s z5
+```
+✅ Correct: Flatten or multiply out
+
+## Parsing Priority
+
+When translating natural language:
+
+1. **Identify repeat pattern**: Look for `Nx(...)` or `N-Mx(...)`
+2. **Extract intensities**: Zone markers, pace descriptors
+3. **Extract durations**: Specific times or ranges
+4. **Calculate base run**: `total_duration - (reps × (work + recovery))`
+5. **Resolve ranges**: Use midpoint for durations, round down for reps
+6. **Format with blank lines**: Always surround repeat blocks
+7. **Validate total duration**: Ensure steps sum to expected time
+
+## Translation Decision Tree
+
+```
+Is there an interval pattern (Nx)?
+├─ YES
+│  ├─ Extract: reps, work duration, recovery description
+│  ├─ Calculate work time from duration or default
+│  ├─ Calculate recovery time from total - work
+│  ├─ Build: base run + blank + Nx + work + recovery + blank + cooldown
+│  └─ Validate: total time matches
+└─ NO
+   └─ Simple step: "- {duration} {intensity}"
+```
+
+## Validation Rules
+
+After translation, verify:
+1. Total duration = sum of all step durations × repetitions
+2. No text before first `-` except section headers
+3. All `Nx` lines are standalone (no `-` prefix)
+4. Blank lines present before/after `Nx` blocks
+5. All steps have duration AND intensity
+6. Intensity format matches sport type (pace for runs, power/watts for rides)

--- a/docs/finalsurge_translations_2026-04-08.md
+++ b/docs/finalsurge_translations_2026-04-08.md
@@ -1,0 +1,213 @@
+# FinalSurge → Intervals.icu Translations
+*Generated 2026-04-08 — last 10 named runs from FinalSurge (60-day window)*
+
+Translations produced by `workout_translator.py` (post Phase-4 + bullet-list parser).
+Each entry shows the FinalSurge description and the resulting Intervals.icu `description` field.
+
+---
+
+## 2026-03-18 | Easy Run (30 min) — *Planned*
+
+**FinalSurge description:** *(none)*
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+```
+
+> **Note:** No description — fallback to total duration at z2.
+
+---
+
+## 2026-03-20 | Easy Run with Strides (30 min) — *Planned*
+
+**FinalSurge description:**
+```
+Run 6-8 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 28m1s z2 pace
+
+7x
+- 17s z1 pace
+```
+
+> **Parser path:** inline `Nx` (6–8 → 7x). Work = 17s (midpoint of 15–20s). No explicit recovery
+> duration (distance-based: 100m), so recovery time is absorbed into the base run.
+>
+> **Known issue:** Stride intensity resolves to `z1 pace` because the intensity scanner reaches
+> "recovery" in the phrase "with full recovery" before it finds "pickups". The `17s` step should
+> ideally be `z5 pace`. Flagged for Phase-5 prompt-assisted fix.
+
+---
+
+## 2026-03-24 | Easy Run (30 min) — *Planned*
+
+**FinalSurge description:** *(none)*
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+```
+
+> **Note:** No description — fallback to total duration at z2.
+
+---
+
+## 2026-03-27 | Easy Run with Strides (45 min) — *Planned*
+
+**FinalSurge description:**
+```
+Run 6-8 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 43m1s z2 pace
+
+7x
+- 17s z1 pace
+```
+
+> **Parser path:** same as 2026-03-20. Base run = 2700s − 7×17s = 2581s = 43m1s.
+>
+> **Known issue:** Same stride intensity issue as above (`z1` vs expected `z5`).
+
+---
+
+## 2026-03-29 | Brick Run Easy (30 min) — *Completed*
+
+**FinalSurge description:** *(none)*
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+```
+
+> **Note:** No description — fallback to total duration at z2.
+
+---
+
+## 2026-03-31 | Easy Run (30 min) — *Planned*
+
+**FinalSurge description:** *(none)*
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+```
+
+> **Note:** No description — fallback to total duration at z2.
+
+---
+
+## 2026-04-02 | Easy Run with Strides (45 min) — *Planned*
+
+**FinalSurge description:**
+```
+Run 6-8 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 43m1s z2 pace
+
+7x
+- 17s z1 pace
+```
+
+> **Parser path:** same as 2026-03-27.
+
+---
+
+## 2026-04-03 | Easy Run with Strides (30 min) — *Planned*
+
+**FinalSurge description:**
+```
+Run 6-8 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 28m1s z2 pace
+
+7x
+- 17s z1 pace
+```
+
+> **Parser path:** same as 2026-03-20.
+
+---
+
+## 2026-04-05 | Brick Run (45 min) — *Planned*
+
+**FinalSurge description:**
+```
+15 mins easy + 2 x 10mins at HMP with 5 mins walk/easy jog rest + 5 mins easy
+```
+
+**Intervals.icu translation:**
+```
+- 15m z2 pace
+
+2x
+- 10m z4 pace
+- 5m z2 pace
+```
+
+> **Parser path:** inline `Nx` (2x). Explicit warmup `15m easy` parsed from text before the `2 x`.
+> Work = 10m @ HMP → `z4 pace`. Recovery = 5m walk/easy jog → `z2 pace`.
+> Total: 15 + 2×(10+5) = 45 min ✓ — no remaining time for a separate cooldown step.
+>
+> **Translation quality: ✅ correct.** The "5 mins easy" at the end of the description
+> is the recovery segment (matched by "with 5 mins walk/easy jog rest"), not a separate cooldown.
+
+---
+
+## 2026-04-07 | Easy Run (30 min) — *Planned*
+
+**FinalSurge description:** *(none)*
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+```
+
+> **Note:** No description — fallback to total duration at z2.
+
+---
+
+## Summary
+
+| Date | Name | Duration | Parser path | Quality |
+|------|------|----------|-------------|---------|
+| 2026-03-18 | Easy Run | 30 min | fallback (no desc) | — |
+| 2026-03-20 | Easy Run with Strides | 30 min | inline Nx | ⚠️ stride intensity z1 vs z5 |
+| 2026-03-24 | Easy Run | 30 min | fallback (no desc) | — |
+| 2026-03-27 | Easy Run with Strides | 45 min | inline Nx | ⚠️ stride intensity z1 vs z5 |
+| 2026-03-29 | Brick Run Easy | 30 min | fallback (no desc) | — |
+| 2026-03-31 | Easy Run | 30 min | fallback (no desc) | — |
+| 2026-04-02 | Easy Run with Strides | 45 min | inline Nx | ⚠️ stride intensity z1 vs z5 |
+| 2026-04-03 | Easy Run with Strides | 30 min | inline Nx | ⚠️ stride intensity z1 vs z5 |
+| 2026-04-05 | Brick Run | 45 min | inline Nx | ✅ correct |
+| 2026-04-07 | Easy Run | 30 min | fallback (no desc) | — |
+
+### Observations for Phase 5
+
+1. **5 of 10 runs have no description** — post-race recovery period (race was 2026-02-01).
+   These correctly fall back to `- Nm z2 pace`.
+
+2. **Strides workout (4×):** The description `"Run 6-8 x 100m or 15-20s pickups, with full recovery"`
+   is parsed correctly as 7×17s repeats, but the stride step maps to `z1 pace` instead of `z5 pace`
+   because the intensity scanner hits `"recovery"` before `"pickups"` in the trailing clause.
+   **Fix:** either add `"pickups"` → `z5 pace` to `INTENSITY_MAP`, or teach the scanner to
+   prioritise the work segment text over the recovery clause.
+
+3. **Brick Run (2026-04-05):** The bullet-list parser was **not** needed here (single prose line
+   with `+` separators), but the inline `Nx` path handled it cleanly. The new bullet-list
+   parser would fire on multi-bullet descriptions — confirmed working in the Phase-4 tests.
+
+4. **No multi-bullet workouts** appeared in this window. The bullet-list parser is validated
+   by unit tests against the `20-10-5` and `2×40min@MP` workout types from `workout_translations.md`.

--- a/docs/finalsurge_translations_premarathon.md
+++ b/docs/finalsurge_translations_premarathon.md
@@ -1,0 +1,565 @@
+# FinalSurge → Intervals.icu Translations: Pre-Marathon Block
+*Generated 2026-04-09 — last 20 runs before 2026-02-01 Surf City Marathon*
+*Translated with `workout_translator.py` post Phase-4 + bullet-list parser + strides template + recovery z1 fixes*
+
+**Parser quality legend:** ✅ correct · ⚠️ minor issue · ❌ broken (distance-based "m=meters" bug or commentary bleed)
+
+---
+
+## 2025-12-23 | 200s and Miles (80 min) ❌
+
+**FinalSurge description:**
+```
+2 sets of :
+- 4 x 200m@3k-5k (45-55s), with 200m jog rest*
+- 2 Mile Tempo at 7:55-8:15
+- 3 mins rest between sets
+
+If you don't have access to a track, then swap the 200s for 1 min on, 1 min off
+```
+
+**Intervals.icu translation:**
+```
+4x
+- 3h20m z2 pace
+- 3h20m z1 pace
+
+- 31m30s z3 pace
+- 3m z1 pace
+```
+
+> ❌ **Broken — distance-based "m = meters" bug.** `200m` is parsed as 200 minutes (3h20m).
+> `2 Mile Tempo` → "2 Mile" has no time unit, so falls through; "7:55-8:15" midpoint becomes
+> 31m30s which is a pace annotation, not a duration. "3 mins rest" → 3m z1 (correct in isolation).
+>
+> **Phase-5 fix needed:** disambiguate metric/imperial distances from minute durations.
+> Heuristic: if value > ~30 and immediately followed by `m` (no following digit/colon), treat as meters.
+
+---
+
+## 2025-12-27 | Pace Change tempo (70 min) ❌
+
+**FinalSurge description:**
+```
+3-4 miles of continuous tempo:
+- 400m@HMP (~8:15-30 pace)
+- 1200m@MP (8:40-9)
+
+The goal of this workout is to manage the change in pace...
+```
+
+**Intervals.icu translation:**
+```
+- 6h40m z4 pace
+- 20h z3 pace
+```
+
+> ❌ **Broken — distance-based "m = meters" bug.** `400m` → 400 min (6h40m), `1200m` → 1200 min (20h).
+> Same root cause as 200s and Miles above.
+
+---
+
+## 2025-12-28 | Long Run (120 min) ✅
+
+**FinalSurge description:**
+```
+Easy pace
+```
+
+**Intervals.icu translation:**
+```
+- 2h z2 pace
+```
+
+> ✅ Simple description, correct fallback.
+
+---
+
+## 2025-12-30 | Cutdown (75 min) ❌
+
+**FinalSurge description:**
+```
+Priority this weekend is the weekend workout...
+- 1.5 miles@HMP or 8:05-15 per mile, 2 mins rest
+- 1.25 miles@HMP or quicker, 8:00-8:10 per mile, 2 mins rest
+- 1 mile @HMP or quicker 7:50-8:00 per mile, 2 mins rest
+- 0.5 mile@10k pace or 7:30-7:45mins per mile (3:45-3:52mins)
+```
+
+**Intervals.icu translation:**
+```
+- 8m5s z1 pace
+- 4m z1 pace
+- 29m z1 pace
+- 18m30s z2 pace
+```
+
+> ❌ **Broken — pace annotations parsed as durations.** "8:05-15" → 8m5s, "8:00-8:10" → 4m (midpoint),
+> "7:50-8:00" → 29m (range badly computed), "7:30-7:45" → 18m30s.
+> The values are min/mile pace, not workout step durations. All steps come out as z1 because "HMP" or
+> "rest" is the dominant intensity token after pace annotation is consumed.
+>
+> **Phase-5 fix needed:** detect "X miles@pace or Y:ZZ per mile" pattern → mark as distance-based,
+> skip or fall back to simple.
+
+---
+
+## 2026-01-02 | Easy Run w/4-6 strides (45 min) — *no description*
+
+**FinalSurge description:** *(none)*
+
+**Intervals.icu translation:**
+```
+- 45m z2 pace
+```
+
+> No description — fallback to total duration at z2.
+> **Note:** Name contains "strides" but strides template only fires on *description* content.
+> Phase-5 could fall back to the strides template when the workout *name* matches.
+
+---
+
+## 2026-01-04 | Marathon Checkpoint (130 min) ⚠️
+
+**FinalSurge description:**
+```
+- 30 mins easy warm up
+- 4 x 15mins at MP with 5 mins rest (walk or easy jog) (1hr 15)
+- Start slower at like 8:45-50 pace, then ok to cutdown the pace
+- 15-25 mins cool down
+```
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+
+4x
+- 15m z3 pace
+- 5m z1 pace
+
+- 8m45s z2 pace
+- 20m z2 pace
+```
+
+> ⚠️ **Mostly correct, one spurious commentary step.** The warm-up (30m z2) ✓, the interval
+> block (4x 15m@MP + 5m z1 recovery) ✓ — recovery correctly z1 because "(walk or easy jog)"
+> is stripped by paren removal, leaving "rest" → z1. The cooldown (15–25 min midpoint = 20m z2) ✓.
+>
+> **Issue:** "Start slower at like 8:45-50 pace" is a coaching cue, not a step. The colon-time
+> pattern `8:45` (8 min 45 s) is parsed as a 8m45s duration. This is a commentary-bullet bleed.
+>
+> **Phase-5 fix:** filter bullets that contain no standalone time unit after removing pace annotations
+> (i.e., "8:45-50 *per mile*" should be disqualified as a step duration).
+
+---
+
+## 2026-01-06 | Easy Run w/Strides (40 min) ✅
+
+**FinalSurge description:**
+```
+4 x 100m strides with full rest (or 15-20s pickups)
+```
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+
+5x
+- 15s z5 pace
+- 1m45s z1 pace
+```
+
+> ✅ **Strides template applied.** "strides" + "pickups" detected → standard 5×(15s z5 / 1m45s z1).
+> Base run = 40 min − 10 min intervals = 30 min z2.
+
+---
+
+## 2026-01-08 | Tempo + Pickups (80 min) ❌
+
+**FinalSurge description:**
+```
+- 3-5 miles@HMP
+- take full rest
+- 4-6 x 30s on / 2 mins off
+```
+
+**Intervals.icu translation:**
+```
+5x
+- 30s z2 pace
+- 2m z2 pace
+```
+
+> ❌ **Broken — two issues.**
+> 1. `3-5 miles@HMP` is distance-based; no duration parsed → entire HMP tempo segment dropped.
+> 2. `4-6 x 30s on / 2 mins off` → 5x correctly, but `"on"` has no intensity mapping → z2 (should
+>    be z5). `"off"` → z2 (should be z1). The word "Pickups" is in the *name* not description.
+>
+> **Phase-5 fixes needed:**
+> - Map `"on"` → `z5 pace` (or detect as the work keyword in "Xon / Yoff" patterns).
+> - Map `"off"` → `z1 pace`.
+> - Handle distance-only tempo bullets with a fallback (e.g., estimate from total time).
+
+---
+
+## 2026-01-09 | Easy Run w/4-6 strides (45 min) — *no description*
+
+**FinalSurge description:** *(none)*
+
+**Intervals.icu translation:**
+```
+- 45m z2 pace
+```
+
+> No description — fallback to total duration at z2.
+
+---
+
+## 2026-01-10 | Long Run with Pickups (140 min) ⚠️
+
+**FinalSurge description:**
+```
+10-12 x 30s on and 2 mins off easy jog
+
+- 30 mins easy
+- 60 mins easy-> moderate
+- 30 mins of workout (30s on / 2 off)
+- 10-20mins easy cool down
+```
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+- 1h z2 pace
+- 30m z2 pace
+- 15m z2 pace
+```
+
+> ⚠️ **Segment structure captured, interval detail lost.** The 4 bullet lines correctly describe
+> the time blocks: 30m easy, 60m easy-moderate, 30m workout, 10–20m cooldown → 135m total (≈ 140m ✓).
+> All resolve to z2 which is reasonable for a mostly-easy long run.
+>
+> The interval detail (`10-12 x 30s on / 2 off`) is in the non-bullet header line and is ignored
+> by the bullet-list parser. "easy->" moderate → arrow notation → z2 (correct for the build portion).
+>
+> **Phase-5:** parse non-bullet header lines alongside bullets; detect embedded Nx in header.
+
+---
+
+## 2026-01-13 | 600s (70 min) ⚠️
+
+**FinalSurge description:**
+```
+- 8 x 600m@Tempo 8:20-30ish pace or 3:07-10 (200m jog rest)
+- If you don't have access to a track, swap to 3 mins on / 1 off
+
+Priority is the weekend workout...
+```
+
+**Intervals.icu translation:**
+```
+8x
+- 8m20s z3 pace
+
+- 3m z2 pace
+```
+
+> ⚠️ **Rep count and intensity correct; duration and fallback step wrong.**
+> `8x` ✓. `z3 pace` (Tempo) ✓.
+> Duration: `8:20` (pace annotation in "8:20-30ish pace") parsed as 8 min 20 s — that's actually
+> the right *order of magnitude* for 8 × 600m tempo reps (true rep ≈ 3:07–3:10 each; 8 × 3:09 = 25m,
+> but the pace per mile "8:20" accidentally works as a plausible proxy duration at 8m20s).
+> However it is semantically wrong (pace ≠ duration).
+>
+> The correct rep duration `3:07-10` was in parentheses and stripped. `(200m jog rest)` also stripped.
+>
+> Second bullet "If you don't have access to a track, swap to 3 mins on / 1 off" → `3m z2` (commentary parsed as step).
+>
+> **Phase-5 fix:** prefer the parenthesised `MM:SS` if present (currently stripped); filter commentary bullets.
+
+---
+
+## 2026-01-14 | Easy Run w/4-6 strides (30 min) — *no description*
+
+**FinalSurge description:** *(none)*
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+```
+
+> No description — fallback to total duration at z2.
+
+---
+
+## 2026-01-16 | Easy Run w/Strides (40 min) ✅
+
+**FinalSurge description:**
+```
+4 x 100m strides with full rest (or 15-20s pickups)
+```
+
+**Intervals.icu translation:**
+```
+- 30m z2 pace
+
+5x
+- 15s z5 pace
+- 1m45s z1 pace
+```
+
+> ✅ Identical description to 2026-01-06. Strides template applied correctly.
+
+---
+
+## 2026-01-17 | Last Big Workout! (150 min) ⚠️
+
+**FinalSurge description:**
+```
+Total Time: 2:30-2:45
+- Hitting total time is first priority, but only do 2:45 if you are feeling good
+- Practice this like race day, and start slower than you think you need to :)
+
+Workout:
+- 45 mins easy
+- 2 x 40mins@MP(8:40-55) with 10 mins easy rest in between
+- 15-30 mins easy
+```
+
+**Intervals.icu translation:**
+```
+- 2m45s z2 pace
+- 45m z2 pace
+
+2x
+- 40m z3 pace
+- 10m z1 pace
+
+- 22m30s z2 pace
+```
+
+> ⚠️ **Core workout correct; two commentary bullets bleed through.**
+>
+> ✅ The key block: `2x 40m@MP + 10m recovery` — MP → z3 ✓, recovery (`"easy rest"`) → z1 ✓.
+> ✅ Cooldown 15–30 min midpoint → 22m30s z2 ✓.
+>
+> ❌ Bullet "only do 2:45 if you are feeling good" → `2:45` colon pattern → 2m45s spurious step.
+> ❌ Bullet "Practice this like race day..." → no duration parsed → correctly dropped ✓.
+> ❌ Bullet "Hitting total time..." → no duration → dropped ✓.
+>
+> **Phase-5 fix:** filter commentary bullets (e.g., bullets with no standalone min/sec unit outside
+> a pace context).
+
+---
+
+## 2026-01-20 | Cutdown (60 min) ❌
+
+**FinalSurge description:**
+```
+4400k Cutdown - 2mins rest all
+- 1600m@Tempo->10k (8:30? who knows after the last big workout lol)
+- 1200m@10k ~5:40-50 or 1:53ish per 400m
+- 800m@5k ~3:40-50 or 1:50ish per 400m
+- 400m@3k ~1:40
+- 2 x 200m@Mile, 48-52s
+```
+
+**Intervals.icu translation:**
+```
+- 26h40m z3 pace
+- 5m40s z2 pace
+- 3m40s z2 pace
+- 1m40s z2 pace
+
+2x
+- 50s z2 pace
+```
+
+> ❌ **Broken — distance-based "m = meters" bug throughout.**
+> `1600m` → 1600 min (26h40m), `1200m` → 1200 min, `800m` → 800 min, `400m` → 400 min.
+> The `2 x 200m` → 2x with 200 min work (shown as `50s` because midpoint of `48-52s` was found first).
+> Effectively unusable. Same root cause as the other distance-based workouts.
+
+---
+
+## 2026-01-23 | Easy Run with Strides (25 min) ✅
+
+**FinalSurge description:**
+```
+Run 4-6 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 15m z2 pace
+
+5x
+- 15s z5 pace
+- 1m45s z1 pace
+```
+
+> ✅ Strides template: 25 min − 10 min = 15 min base run. Correct.
+
+---
+
+## 2026-01-24 | Last Workout! (90 min) ⚠️
+
+**FinalSurge description:**
+```
+45 mins easy to moderate
+30mins at goal marathon pace: 8:40-9:00
+15 mins cool down
+
+If feeling tired, shorten even more! Cutdown the 45mins to 30
+```
+
+**Intervals.icu translation:**
+```
+- 1h30m z3 pace
+```
+
+> ⚠️ **No bullet lines → simple fallback.** "marathon pace" found in full description → z3 pace.
+> Duration = total 90m. The three-segment structure (45m easy + 30m MP + 15m cooldown) is not
+> captured because there are no bullet lines to trigger the bullet-list parser, and no Nx repeat.
+>
+> **Phase-5 fix:** detect non-bullet multi-segment descriptions (lines with explicit durations
+> separated by newlines) and parse them the same way as bullet lists.
+
+---
+
+## 2026-01-27 | Pre-Race! (45 min) ❌
+
+**FinalSurge description:**
+```
+2-3 x Mile Progressive with 90s rest
+- Marathon Pace -> Half Pace -> 10k pace
+- 8:45-9:00 to 8:30-45 to 8:15-30 (roughly)
+- Take 3-5mins rest
+- then run 2-4 x 200m@5k (or faster than last mile repeat) with 200m jog rest
+```
+
+**Intervals.icu translation:**
+```
+- 27m z2 pace
+- 4m z1 pace
+
+3x
+- 3h20m z2 pace
+- 3h20m z1 pace
+```
+
+> ❌ **Broken — distance + pace annotation confusion throughout.**
+> Bullet-list parser fires (4 bullets). `200m` → 200 min (3h20m) — distance bug again.
+> `8:45-9:00` in bullet 2 → pace annotation parsed as time range.
+> The `3x` block represents "2-4 x 200m@5k" which is valid structurally but the duration is nonsense.
+> `- 27m z2 pace` comes from the 4-minute rest bullet ("Take 3-5mins rest" midpoint = 4m z1 — shown
+> above the 3x block because... actually this is from the `90s` rest in the non-bullet header line
+> being parsed by `_parse_surrounding`).
+
+---
+
+## 2026-01-30 | Easy Run (30 min) ✅
+
+**FinalSurge description:**
+```
+Run 6-8 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 20m z2 pace
+
+5x
+- 15s z5 pace
+- 1m45s z1 pace
+```
+
+> ✅ Strides template: 30 min − 10 min = 20 min base run.
+
+---
+
+## 2026-01-31 | Easy Run w/Strides (20 min) ✅
+
+**FinalSurge description:**
+```
+Run 4-6 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 10m z2 pace
+
+5x
+- 15s z5 pace
+- 1m45s z1 pace
+```
+
+> ✅ Strides template: 20 min − 10 min = 10 min base run.
+
+---
+
+## Summary
+
+| Date | Workout | Duration | Quality | Parser path |
+|------|---------|----------|---------|-------------|
+| 2025-12-23 | 200s and Miles | 80 min | ❌ | bullet-list, m=meters bug |
+| 2025-12-27 | Pace Change tempo | 70 min | ❌ | bullet-list, m=meters bug |
+| 2025-12-28 | Long Run | 120 min | ✅ | simple (easy pace) |
+| 2025-12-30 | Cutdown | 75 min | ❌ | bullet-list, pace=duration confusion |
+| 2026-01-02 | Easy Run w/4-6 strides | 45 min | — | no-desc fallback |
+| 2026-01-04 | Marathon Checkpoint | 130 min | ⚠️ | bullet-list + inline Nx, 1 commentary step |
+| 2026-01-06 | Easy Run w/Strides | 40 min | ✅ | strides template |
+| 2026-01-08 | Tempo + Pickups | 80 min | ❌ | bullet-list, distance drop + "on/off" unmapped |
+| 2026-01-09 | Easy Run w/4-6 strides | 45 min | — | no-desc fallback |
+| 2026-01-10 | Long Run with Pickups | 140 min | ⚠️ | bullet-list, segments correct, intervals lost |
+| 2026-01-13 | 600s | 70 min | ⚠️ | bullet-list + inline Nx, rep count+intensity ✓, duration wrong, commentary step |
+| 2026-01-14 | Easy Run w/4-6 strides | 30 min | — | no-desc fallback |
+| 2026-01-16 | Easy Run w/Strides | 40 min | ✅ | strides template |
+| 2026-01-17 | Last Big Workout! | 150 min | ⚠️ | bullet-list + inline Nx, core correct, 1 commentary step |
+| 2026-01-20 | Cutdown | 60 min | ❌ | bullet-list, m=meters bug throughout |
+| 2026-01-23 | Easy Run with Strides | 25 min | ✅ | strides template |
+| 2026-01-24 | Last Workout! | 90 min | ⚠️ | simple fallback (no bullets), loses segment structure |
+| 2026-01-27 | Pre-Race! | 45 min | ❌ | bullet-list, m=meters + pace annotation confusion |
+| 2026-01-30 | Easy Run | 30 min | ✅ | strides template |
+| 2026-01-31 | Easy Run w/Strides | 20 min | ✅ | strides template |
+
+**Score: 6 ✅ · 4 ⚠️ · 4 ❌ · 3 no-desc (fallback)**
+
+---
+
+## Phase-5 Bug Priority List
+
+Ordered by frequency and impact across this dataset:
+
+### P1 — `m` disambiguation (meters vs. minutes)
+Affects: 200s and Miles, Pace Change tempo, Cutdown ×2, Pre-Race! (5 workouts broken)
+
+Distance values like `200m`, `400m`, `600m`, `800m`, `1200m`, `1600m` are parsed as minutes.
+**Heuristic:** if a bare integer > 30 is immediately followed by `m` (and not followed by another
+digit or `/km`), treat it as meters and skip the duration parse for that token.
+
+### P2 — Commentary-bullet bleed
+Affects: Marathon Checkpoint, Last Big Workout!, 600s (3 workouts with spurious steps)
+
+Bullet lines that are coaching cues (not workout steps) are parsed as steps because they happen
+to contain time-like strings (`2:45`, pace ranges like `8:20-30`).
+**Heuristic:** a bullet line whose *only* numeric token is a pace annotation (i.e., `HH:MM` preceded
+or followed by "pace", "per mile", "per km", or a slash-fraction) should be excluded from step parsing.
+
+### P3 — Non-bullet multi-segment descriptions
+Affects: Last Workout! (1 workout)
+
+Three-part structure `45 mins easy\n30mins at MP\n15 mins cool down` (no dashes) falls through to
+the simple parser. Extend bullet-list logic to also handle plain newline-separated duration lines.
+
+### P4 — `"on"` / `"off"` intensity keywords
+Affects: Tempo + Pickups, Long Run with Pickups
+
+`"30s on / 2 mins off"` pattern: `"on"` should map to z5, `"off"` to z1.
+Add to `INTENSITY_MAP`: `"on": "z5 pace"`, `"off": "z1 pace"`.
+
+### P5 — Strides template triggered by workout *name* (no description)
+Affects: 3 no-description strides workouts
+
+When description is empty but workout name contains "strides" or "pickups", apply the strides
+template instead of the plain `- Nm z2 pace` fallback.

--- a/docs/workout_translations.md
+++ b/docs/workout_translations.md
@@ -1,0 +1,520 @@
+# FinalSurge Workout Translations: Dec 1 2025 - Feb 1 2026
+
+Translated using `translate_workout()` from `workout_translator.py`.
+
+> **Note on translation quality:** Most workouts in this plan use prose/bullet descriptions
+> rather than the `Nx(work / recovery)` structured format. The translator correctly detects
+> repeat blocks when present; otherwise it falls back to a single-step summary using the
+> dominant intensity. Workouts marked with a single step are candidates for manual review
+> or the Claude-assisted translation path (Phase 5 of the roadmap).
+
+---
+## 2025-12-01 -- 9 Weeks to go!
+> Up Week!
+
+### 2025-12-03 | Strength Training | Power Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/1DJ501aYpHzdOxBY4GrI875lVWklEG2cwW2CnsLJ1JjE/edit?usp=drive_link)*
+
+### 2025-12-04 | Run | Easy Run (30 min)
+
+*No description -- 30 min run at easy effort*
+
+### 2025-12-05 | Run | Easy Run (30 min)
+
+*No description -- 30 min run at easy effort*
+
+### 2025-12-06 | Strength Training | Power Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/1DJ501aYpHzdOxBY4GrI875lVWklEG2cwW2CnsLJ1JjE/edit?usp=drive_link)*
+
+### 2025-12-06 | Run | 4 mins on / 2 off (80 min)
+
+**FinalSurge description:**
+```
+- 8 x 4:00mins @MP->HMP and 2:00mins easy
+- By effort*
+- Total Workout Time: 48 mins
+- 20 easy + 48 w/o + 10 down
+- Aim for 80-90 mins total
+```
+
+**Intervals.icu translation:**
+```
+- 1h20m z2 pace
+```
+
+---
+## 2025-12-08 -- 8 Weeks to go!
+> Up Week!
+
+### 2025-12-09 | Run | Easy Run (30 min)
+
+*No description -- 30 min run at easy effort*
+
+### 2025-12-10 | Strength Training | Power Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/1DJ501aYpHzdOxBY4GrI875lVWklEG2cwW2CnsLJ1JjE/edit?usp=drive_link)*
+
+### 2025-12-10 | Run | 800s (70 min)
+
+**FinalSurge description:**
+```
+6-8 x 800s or 3 mins repeats with 400m or 1 min easy jog or walk rest
+- Start at your half pace (8:28) and cut down to about 8 mins or 4 mins for each 800m repeat
+- Warm-up for 15mins
+- Workout ~45mins
+- Cool down 5-10 mins
+```
+
+**Intervals.icu translation:**
+```
+- 1h10m z2 pace
+```
+
+### 2025-12-12 | Run | Easy Run (30 min)
+
+*No description -- 30 min run at easy effort*
+
+### 2025-12-13 | Strength Training | Power Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/1DJ501aYpHzdOxBY4GrI875lVWklEG2cwW2CnsLJ1JjE/edit?usp=drive_link)*
+
+### 2025-12-13 | Run | 20-10-5 (75 min)
+
+**FinalSurge description:**
+```
+- 20 mins warm up Easy
+- 20 mins at marathon pace (effort)
+- 5 mins easy jog or walking
+- 10 mins at marathon pace (effort)
+- 5 mins easy jog or walking
+- 5 mins at half marathon pace
+- 10 mins cool down easy
+```
+
+**Intervals.icu translation:**
+```
+- 1h15m z4 pace
+```
+
+---
+## 2025-12-15 -- 7 Weeks to go!
+> Down Week!
+
+### 2025-12-16 | Run | (unnamed) (40 min)
+
+*No description -- 40 min run at easy effort*
+
+### 2025-12-17 | Strength Training | Speed and Efficiency Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/12vkWmyxHCaDfJp_P93sfhwAvFJFc_7OAk8jrCW6mnac/edit?usp=drive_link)*
+
+### 2025-12-17 | Run | Easy Run (30 min)
+
+*No description -- 30 min run at easy effort*
+
+### 2025-12-18 | Run | Mile Repeats (80 min)
+
+**FinalSurge description:**
+```
+- 15-20 mins warm up
+- 3-5 x Mile at Half Marathon pace (8:30ish ?), with 90s rest
+- 10-15mins cool down
+```
+
+**Intervals.icu translation:**
+```
+- 1h20m z4 pace
+```
+
+### 2025-12-20 | Strength Training | Speed and Efficiency Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/12vkWmyxHCaDfJp_P93sfhwAvFJFc_7OAk8jrCW6mnac/edit?usp=drive_link)*
+
+### 2025-12-20 | Run | Long run w/Pickups (100 min)
+
+**FinalSurge description:**
+```
+Run Easy for 1 hour, then do:
+- 6-8 x 30s on / 3 mins off
+- cool down to remaining time
+
+"On" pace is like 5k, or comfortable hard for 30s (not all out)
+```
+
+**Intervals.icu translation:**
+```
+- 1h40m z2 pace
+```
+
+---
+## 2025-12-22 -- 6 Weeks to go!
+> Up Week!
+
+### 2025-12-23 | Run | 200s and Miles (80 min)
+
+**FinalSurge description:**
+```
+2 sets of :
+- 4 x 200m@3k-5k (45-55s), with 200m jog rest*
+- 2 Mile Tempo at 7:55-8:15
+- 3 mins rest between sets
+
+If you don't have access to a track, then swap the 200s for 1 min on, 1 min off
+```
+
+**Intervals.icu translation:**
+```
+- 1h20m z3 pace
+```
+
+### 2025-12-24 | Strength Training | Speed and Efficiency Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/12vkWmyxHCaDfJp_P93sfhwAvFJFc_7OAk8jrCW6mnac/edit?usp=drive_link)*
+
+### 2025-12-25 | Run | (unnamed) (60 min)
+
+*No description -- 60 min run at easy effort*
+
+### 2025-12-27 | Strength Training | Speed and Efficiency Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/12vkWmyxHCaDfJp_P93sfhwAvFJFc_7OAk8jrCW6mnac/edit?usp=drive_link)*
+
+### 2025-12-27 | Run | Pace Change tempo (70 min)
+
+**FinalSurge description:**
+```
+3-4 miles of continuous tempo:
+- 400m@HMP (~8:15-30 pace)
+- 1200m@MP (8:40-9)
+
+The goal of this workout is to manage the change in pace - in a marathon sometimes you have a rough mile or stop in the bathroom, etc., so this is to help you reset your paces
+```
+
+**Intervals.icu translation:**
+```
+- 1h10m z3 pace
+```
+
+### 2025-12-28 | Run | Long Run (120 min)
+
+**FinalSurge description:**
+```
+Easy pace
+```
+
+**Intervals.icu translation:**
+```
+- 2h z2 pace
+```
+
+---
+## 2025-12-29 -- 5 Weeks to go!
+> Up Week!
+
+### 2025-12-30 | Run | Cutdown (75 min)
+
+**FinalSurge description:**
+```
+Priority this weekend is the weekend workout, so if you are feeling tired then cut this one short / go slower.
+- 1.5 miles@HMP or 8:05-15 per mile, 2 mins rest
+- 1.25 miles@HMP or quicker, 8:00-8:10 per mile, 2 mins rest
+- 1 mile @HMP or quicker 7:50-8:00 per mile, 2 mins rest
+- 0.5 mile@10k pace or 7:30-7:45mins per mile (3:45-3:52mins)
+```
+
+**Intervals.icu translation:**
+```
+- 1h15m z4 pace
+```
+
+### 2025-12-31 | Strength Training | Speed and Efficiency Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/12vkWmyxHCaDfJp_P93sfhwAvFJFc_7OAk8jrCW6mnac/edit?usp=drive_link)*
+
+### 2026-01-02 | Run | Easy Run w/4-6 strides (45 min)
+
+*No description -- 45 min run at easy effort*
+
+### 2026-01-03 | Strength Training | Speed and Efficiency Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/12vkWmyxHCaDfJp_P93sfhwAvFJFc_7OAk8jrCW6mnac/edit?usp=drive_link)*
+
+### 2026-01-03 | Run | (unnamed) (60 min)
+
+*No description -- 60 min run at easy effort*
+
+---
+## 2026-01-04 -- Training Tip of the Week
+> To avoid overuse injuries, most coaches would say never increase your running training more than 10% per week. A good rule to train by, but most athletes can increase more than this number when building back into training or returning from a taper or down week. The best thing you can do is to know your own personal limits!
+
+### 2026-01-04 | Run | Marathon Checkpoint (130 min)
+
+**FinalSurge description:**
+```
+- 30 mins easy warm up
+- 4 x 15mins at MP with 5 mins rest (walk or easy jog) (1hr 15)
+- Start slower at like 8:45-50 pace, then ok to cutdown the pace
+- 15-25 mins cool down
+```
+
+**Intervals.icu translation:**
+```
+- 2h10m z2 pace
+```
+
+---
+## 2026-01-05 -- 4 Weeks to go!
+> Up Week!
+
+### 2026-01-06 | Run | Easy Run w/Strides (40 min)
+
+**FinalSurge description:**
+```
+4 x 100m strides with full rest (or 15-20s pickups)
+```
+
+**Intervals.icu translation:**
+```
+- 40m z5 pace
+```
+
+### 2026-01-07 | Strength Training | Speed and Efficiency Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/12vkWmyxHCaDfJp_P93sfhwAvFJFc_7OAk8jrCW6mnac/edit?usp=drive_link)*
+
+### 2026-01-08 | Run | Tempo + Pickups (80 min)
+
+**FinalSurge description:**
+```
+- 3-5 miles@HMP
+- take full rest
+- 4-6 x 30s on / 2 mins off
+```
+
+**Intervals.icu translation:**
+```
+- 1h20m z4 pace
+```
+
+### 2026-01-09 | Run | Easy Run w/4-6 strides (45 min)
+
+*No description -- 45 min run at easy effort*
+
+### 2026-01-10 | Strength Training | Speed and Efficiency Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/12vkWmyxHCaDfJp_P93sfhwAvFJFc_7OAk8jrCW6mnac/edit?usp=drive_link)*
+
+### 2026-01-10 | Run | Long Run with Pickups (140 min)
+
+**FinalSurge description:**
+```
+10-12 x 30s on and 2 mins off easy jog
+
+- 30 mins easy 
+- 60 mins easy-> moderate
+- 30 mins of workout (30s on / 2 off)
+- 10-20mins easy cool down
+```
+
+**Intervals.icu translation:**
+```
+- 2h20m z2 pace
+```
+
+---
+## 2026-01-11 -- Training Tip of the Week!
+> Another training "rule" this week: 80 / 20. You may be familiar with this rule from mathematics or statistics class, but for running/endurance, it means 80% of your total volume should be easy or L1. The 80% helps ensure that your body's engine is prepped and ready for the 20% hard intensity. Similar to the foundation of a house being sturdy to hold up the rest of the house.
+
+---
+## 2026-01-12 -- 3 Weeks to go!
+> Slight down week
+
+### 2026-01-13 | Run | 600s (70 min)
+
+**FinalSurge description:**
+```
+- 8 x 600m@Tempo 8:20-30ish pace or 3:07-10 (200m jog rest)
+- If you don't have access to a track, swap to 3 mins on / 1 off
+
+Priority is the weekend workout, so listen to your body and don't be afraid to shorten the workout or go slower if needed.
+```
+
+**Intervals.icu translation:**
+```
+- 1h10m z3 pace
+```
+
+### 2026-01-14 | Strength Training | Maintenance Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/1uURhNNUIJG4bk9srh8Fpy-oJ_zrsfQeF58Lbv3iUZ6g/edit?usp=drive_link)*
+
+### 2026-01-14 | Run | Easy Run w/4-6 strides (30 min)
+
+*No description -- 30 min run at easy effort*
+
+### 2026-01-16 | Run | Easy Run w/Strides (40 min)
+
+**FinalSurge description:**
+```
+4 x 100m strides with full rest (or 15-20s pickups)
+```
+
+**Intervals.icu translation:**
+```
+- 40m z5 pace
+```
+
+### 2026-01-17 | Strength Training | Maintenance Strength (60 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/1uURhNNUIJG4bk9srh8Fpy-oJ_zrsfQeF58Lbv3iUZ6g/edit?usp=drive_link)*
+
+### 2026-01-17 | Run | Last Big Workout! (150 min)
+
+**FinalSurge description:**
+```
+Total Time: 2:30-2:45
+- Hitting total time is first priority, but only do 2:45 if you are feeling good
+- Practice this like race day, and start slower than you think you need to :)
+
+Workout:
+- 45 mins easy
+- 2 x 40mins@MP(8:40-55) with 10 mins easy rest in between
+- 15-30 mins easy
+```
+
+**Intervals.icu translation:**
+```
+- 2h30m z2 pace
+```
+
+---
+## 2026-01-18 -- Training Tip of the Week
+> "Hard Days Hard, Easy Days Easy". Doing workouts, high intensity, and strength training are all activities that tear and break down muscles. Easy days help with blood flow and allow the muscles to recover and adapt to training. Tuesday night workout + Weds AM strength is an example of keeping the harder efforts closer together to allow for more recovery time between workouts. Everyone is different though - some people need strength on Thursday instead of Tues/Weds - figure out what works best for you!
+
+---
+## 2026-01-18 -- 14 Weeks to Eugene / 15 Weeks to Vancouver
+> Logan
+
+---
+## 2026-01-19 -- 2 Weeks to go!
+> Taper Week - 50% reduction in volume!
+
+### 2026-01-20 | Run | Cutdown (60 min)
+
+**FinalSurge description:**
+```
+4400k Cutdown - 2mins rest all
+- 1600m@Tempo->10k (8:30? who knows after the last big workout lol)
+- 1200m@10k ~5:40-50 or 1:53ish per 400m
+- 800m@5k ~3:40-50 or 1:50ish per 400m
+- 400m@3k ~1:40
+- 2 x 200m@Mile, 48-52s
+```
+
+**Intervals.icu translation:**
+```
+- 1h z3 pace
+```
+
+### 2026-01-21 | Strength Training | Maintenance Strength (45 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/1uURhNNUIJG4bk9srh8Fpy-oJ_zrsfQeF58Lbv3iUZ6g/edit?usp=drive_link)*
+
+### 2026-01-23 | Run | Easy Run with Strides (25 min)
+
+**FinalSurge description:**
+```
+Run 4-6 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 25m z1 pace
+```
+
+### 2026-01-24 | Strength Training | Maintenance Strength (45 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/1uURhNNUIJG4bk9srh8Fpy-oJ_zrsfQeF58Lbv3iUZ6g/edit?usp=drive_link)*
+
+### 2026-01-24 | Run | Last Workout! (90 min)
+
+**FinalSurge description:**
+```
+45 mins easy to moderate
+30mins at goal marathon pace: 8:40-9:00
+15 mins cool down
+
+If feeling tired, shorten even more! Cutdown the 45mins to 30
+```
+
+**Intervals.icu translation:**
+```
+- 1h30m z3 pace
+```
+
+---
+## 2026-01-25 -- Training Tip of the Week
+> Alternating Hard/Easy Days. The quickest path to injury is doing 2 interval workouts one day after another. The body needs time to repair the muscle damage from the first workout. 
+
+---
+## 2026-01-25 -- 13 Weeks to Eugene / 14 Weeks to Vancouver
+
+---
+## 2026-01-26 -- 1 Weeks to go!
+> Down Week!
+
+### 2026-01-27 | Run | Pre-Race! (45 min)
+
+**FinalSurge description:**
+```
+2-3 x Mile Progressive with 90s rest
+- Marathon Pace -> Half Pace -> 10k pace
+- 8:45-9:00 to 8:30-45 to 8:15-30 (roughly)
+- Take 3-5mins rest
+- then run 2-4 x 200m@5k (or faster than last mile repeat) with 200m jog rest
+```
+
+**Intervals.icu translation:**
+```
+- 45m z3 pace
+```
+
+### 2026-01-28 | Strength Training | Maintenance Strength (30 min)
+
+*Strength workout -- see [linked document](https://docs.google.com/document/d/1uURhNNUIJG4bk9srh8Fpy-oJ_zrsfQeF58Lbv3iUZ6g/edit?usp=drive_link)*
+
+### 2026-01-30 | Run | Easy Run (30 min)
+
+**FinalSurge description:**
+```
+Run 6-8 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 30m z1 pace
+```
+
+---
+## 2026-01-31 -- Race Weekend!
+
+### 2026-01-31 | Run | Easy Run w/Strides (20 min)
+
+**FinalSurge description:**
+```
+Run 4-6 x 100m or 15-20s pickups, with full recovery
+```
+
+**Intervals.icu translation:**
+```
+- 20m z1 pace
+```
+
+---
+## 2026-02-01 -- Training Tip of the Week
+> Strength training is an essential part of a running program. However, studies done on athletes are highly inconclusive. This is because the individual strength needs are variable and not everyone needs the same strength training to be injury free. For example, Coach Ashley needs a lot less leg strength to stay injury free - but adds in strength when needed, such as adding in calf strength training for her ultra - to be ready for those hills!
+
+---
+## 2026-02-01 -- 12 Weeks to Eugene + Whidbey / 13 Weeks to Vancouver

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -13,6 +13,7 @@ from .models import (
     ActivitySummary,
     Athlete,
     BestEffort,
+    DataCurvePt,
     Event,
     Folder,
     Gear,
@@ -573,6 +574,9 @@ class ICUClient:
     ) -> PowerCurve:
         """Get power curve data (best efforts for various durations).
 
+        Uses the activity-power-curves endpoint which supports date range filtering
+        and returns per-activity parallel arrays. Aggregates to best effort per duration.
+
         Args:
             athlete_id: Athlete ID (uses config default if not provided)
             oldest: Oldest date to include (ISO-8601 format)
@@ -590,8 +594,38 @@ class ICUClient:
         if newest:
             params["newest"] = newest
 
-        response = await self._request("GET", f"/athlete/{athlete_id}/power-curves", params=params)
-        return PowerCurve(**response.json())
+        response = await self._request(
+            "GET", f"/athlete/{athlete_id}/activity-power-curves", params=params
+        )
+        payload = response.json()
+        secs: list[int] = payload.get("secs") or []
+        curves: list[dict[str, Any]] = payload.get("curves") or []
+
+        # Build best-effort per duration across all activity curves
+        data_points: list[DataCurvePt] = []
+        for i, sec in enumerate(secs):
+            best_watts: int | None = None
+            best_activity_id: str | None = None
+            best_date: str | None = None
+            for curve in curves:
+                watts_list: list[int] = curve.get("watts") or []
+                if i < len(watts_list) and watts_list[i] is not None:
+                    w = watts_list[i]
+                    if best_watts is None or w > best_watts:
+                        best_watts = w
+                        best_activity_id = curve.get("id")
+                        best_date = curve.get("start_date_local")
+            if best_watts is not None:
+                data_points.append(
+                    DataCurvePt(
+                        secs=sec,
+                        watts=best_watts,
+                        src_activity_id=best_activity_id,
+                        date=best_date,
+                    )
+                )
+
+        return PowerCurve(data=data_points)
 
     async def get_hr_curves(
         self,
@@ -600,6 +634,9 @@ class ICUClient:
         newest: str | None = None,
     ) -> HRCurve:
         """Get heart rate curve data (best efforts for various durations).
+
+        Uses the activity-hr-curves endpoint which supports date range filtering
+        and returns per-activity parallel arrays. Aggregates to best effort per duration.
 
         Args:
             athlete_id: Athlete ID (uses config default if not provided)
@@ -610,15 +647,44 @@ class ICUClient:
             HRCurve with best efforts data
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {}
+        params: dict[str, Any] = {}
 
         if oldest:
             params["oldest"] = oldest
         if newest:
             params["newest"] = newest
 
-        response = await self._request("GET", f"/athlete/{athlete_id}/hr-curves", params=params)
-        return HRCurve(**response.json())
+        response = await self._request(
+            "GET", f"/athlete/{athlete_id}/activity-hr-curves", params=params
+        )
+        payload = response.json()
+        secs: list[int] = payload.get("secs") or []
+        curves: list[dict[str, Any]] = payload.get("curves") or []
+
+        data_points: list[DataCurvePt] = []
+        for i, sec in enumerate(secs):
+            best_bpm: int | None = None
+            best_activity_id: str | None = None
+            best_date: str | None = None
+            for curve in curves:
+                bpm_list: list[int] = curve.get("bpm") or []
+                if i < len(bpm_list) and bpm_list[i] is not None:
+                    b = bpm_list[i]
+                    if best_bpm is None or b > best_bpm:
+                        best_bpm = b
+                        best_activity_id = curve.get("id")
+                        best_date = curve.get("start_date_local")
+            if best_bpm is not None:
+                data_points.append(
+                    DataCurvePt(
+                        secs=sec,
+                        bpm=best_bpm,
+                        src_activity_id=best_activity_id,
+                        date=best_date,
+                    )
+                )
+
+        return HRCurve(data=data_points)
 
     async def get_pace_curves(
         self,
@@ -628,6 +694,9 @@ class ICUClient:
         use_gap: bool = False,
     ) -> PaceCurve:
         """Get pace curve data (best efforts for various durations).
+
+        Uses the activity-pace-curves endpoint which supports date range filtering
+        and returns per-activity parallel arrays. Aggregates to best (fastest) pace per duration.
 
         Args:
             athlete_id: Athlete ID (uses config default if not provided)
@@ -639,7 +708,7 @@ class ICUClient:
             PaceCurve with best efforts data
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {}
+        params: dict[str, Any] = {}
 
         if oldest:
             params["oldest"] = oldest
@@ -648,8 +717,38 @@ class ICUClient:
         if use_gap:
             params["gap"] = "true"
 
-        response = await self._request("GET", f"/athlete/{athlete_id}/pace-curves", params=params)
-        return PaceCurve(**response.json())
+        response = await self._request(
+            "GET", f"/athlete/{athlete_id}/activity-pace-curves", params=params
+        )
+        payload = response.json()
+        secs: list[int] = payload.get("secs") or []
+        curves: list[dict[str, Any]] = payload.get("curves") or []
+
+        data_points: list[DataCurvePt] = []
+        for i, sec in enumerate(secs):
+            # Best pace = lowest value (faster is smaller min/km)
+            best_pace: float | None = None
+            best_activity_id: str | None = None
+            best_date: str | None = None
+            for curve in curves:
+                pace_list: list[float] = curve.get("pace") or []
+                if i < len(pace_list) and pace_list[i] is not None:
+                    p = pace_list[i]
+                    if best_pace is None or p < best_pace:
+                        best_pace = p
+                        best_activity_id = curve.get("id")
+                        best_date = curve.get("start_date_local")
+            if best_pace is not None:
+                data_points.append(
+                    DataCurvePt(
+                        secs=sec,
+                        pace=best_pace,
+                        src_activity_id=best_activity_id,
+                        date=best_date,
+                    )
+                )
+
+        return PaceCurve(data=data_points)
 
     # ==================== Workout Library Endpoints ====================
 

--- a/src/intervals_icu_mcp/client.py
+++ b/src/intervals_icu_mcp/client.py
@@ -260,7 +260,7 @@ class ICUClient:
             List of Activity objects around the reference activity
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {"id": activity_id, "count": count}
+        params = {"activity_id": activity_id, "count": count}
 
         response = await self._request(
             "GET", f"/athlete/{athlete_id}/activities-around", params=params
@@ -358,7 +358,7 @@ class ICUClient:
             Histogram with power distribution bins
         """
         response = await self._request("GET", f"/activity/{activity_id}/power-histogram")
-        return Histogram(**response.json())
+        return Histogram(bins=response.json())
 
     async def get_hr_histogram(
         self,
@@ -373,7 +373,7 @@ class ICUClient:
             Histogram with HR distribution bins
         """
         response = await self._request("GET", f"/activity/{activity_id}/hr-histogram")
-        return Histogram(**response.json())
+        return Histogram(bins=response.json())
 
     async def get_pace_histogram(
         self,
@@ -388,7 +388,7 @@ class ICUClient:
             Histogram with pace distribution bins
         """
         response = await self._request("GET", f"/activity/{activity_id}/pace-histogram")
-        return Histogram(**response.json())
+        return Histogram(bins=response.json())
 
     async def get_gap_histogram(
         self,
@@ -403,7 +403,7 @@ class ICUClient:
             Histogram with GAP distribution bins
         """
         response = await self._request("GET", f"/activity/{activity_id}/gap-histogram")
-        return Histogram(**response.json())
+        return Histogram(bins=response.json())
 
     # ==================== Wellness Endpoints ====================
 
@@ -569,6 +569,7 @@ class ICUClient:
         athlete_id: str | None = None,
         oldest: str | None = None,
         newest: str | None = None,
+        activity_type: str = "Ride",
     ) -> PowerCurve:
         """Get power curve data (best efforts for various durations).
 
@@ -576,12 +577,13 @@ class ICUClient:
             athlete_id: Athlete ID (uses config default if not provided)
             oldest: Oldest date to include (ISO-8601 format)
             newest: Newest date to include (ISO-8601 format)
+            activity_type: Activity type to filter by (e.g., "Ride", "VirtualRide")
 
         Returns:
             PowerCurve with best efforts data
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {}
+        params: dict[str, Any] = {"type": activity_type}
 
         if oldest:
             params["oldest"] = oldest
@@ -683,8 +685,10 @@ class ICUClient:
             List of Interval objects
         """
         response = await self._request("GET", f"/activity/{activity_id}/intervals")
+        data = response.json()
+        intervals_list = data.get("icu_intervals") or data.get("intervals") or (data if isinstance(data, list) else [])
         adapter = TypeAdapter(list[Interval])
-        return adapter.validate_python(response.json())
+        return adapter.validate_python(intervals_list)
 
     async def get_activity_streams(
         self,
@@ -706,23 +710,37 @@ class ICUClient:
             params["types"] = ",".join(streams)
 
         response = await self._request("GET", f"/activity/{activity_id}/streams", params=params)
-        return ActivityStreams(**response.json())
+        raw = response.json()
+        streams_dict = {s["type"]: s["data"] for s in raw if "type" in s and "data" in s}
+        return ActivityStreams(**streams_dict)
 
     async def get_best_efforts(
         self,
         activity_id: str,
+        stream: str = "watts",
+        duration: int | None = None,
     ) -> list[BestEffort]:
         """Get best efforts for an activity.
 
         Args:
             activity_id: Activity ID
+            stream: Stream type to compute best efforts from ('watts', 'heartrate', 'velocity_smooth')
+            duration: Optional duration in seconds (if not specified, returns standard best efforts)
 
         Returns:
             List of BestEffort objects
         """
-        response = await self._request("GET", f"/activity/{activity_id}/best-efforts")
+        params: dict[str, Any] = {"stream": stream}
+        # API requires either duration or distance; default to 5 minutes (300 secs)
+        params["duration"] = duration or 300
+
+        response = await self._request(
+            "GET", f"/activity/{activity_id}/best-efforts", params=params
+        )
+        data = response.json()
+        efforts = data["efforts"] if isinstance(data, dict) and "efforts" in data else data
         adapter = TypeAdapter(list[BestEffort])
-        return adapter.validate_python(response.json())
+        return adapter.validate_python(efforts)
 
     async def search_intervals(
         self,
@@ -745,14 +763,15 @@ class ICUClient:
             List of matching intervals with activity context
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        params = {}
+        params: dict[str, Any] = {
+            "minIntensity": 0,
+            "maxIntensity": 100,
+            "minSecs": min_duration or 0,
+            "maxSecs": max_duration or 86400,
+        }
 
         if interval_type:
             params["type"] = interval_type
-        if min_duration:
-            params["minDuration"] = min_duration
-        if max_duration:
-            params["maxDuration"] = max_duration
 
         response = await self._request(
             "GET", f"/athlete/{athlete_id}/activities/interval-search", params=params
@@ -777,7 +796,7 @@ class ICUClient:
             List of Workout objects
         """
         athlete_id = athlete_id or self.config.intervals_icu_athlete_id
-        response = await self._request("GET", f"/athlete/{athlete_id}/folders/{folder_id}/workouts")
+        response = await self._request("GET", f"/athlete/{athlete_id}/workouts", params={"folder_id": folder_id})
         adapter = TypeAdapter(list[Workout])
         return adapter.validate_python(response.json())
 

--- a/src/intervals_icu_mcp/models.py
+++ b/src/intervals_icu_mcp/models.py
@@ -17,11 +17,12 @@ class SportSettings(BaseModel):
     """Sport-specific settings for an athlete."""
 
     id: int
-    type: str | None = None
+    type: str | None = None  # singular sport type from API (e.g. "Ride")
+    types: list[str] = Field(default_factory=list)  # multi-type variant
     ftp: int | None = None
-    fthr: int | None = None
-    pace_threshold: float | None = None
-    swim_threshold: float | None = None
+    lthr: int | None = None
+    threshold_pace: float | None = None
+    pace_units: str | None = None
 
 
 class Athlete(BaseModel):
@@ -419,7 +420,7 @@ class HistogramBin(BaseModel):
 
     min: float  # Minimum value for this bin
     max: float  # Maximum value for this bin
-    count: int  # Number of data points in this bin
+    count: int | None = None  # Number of data points in this bin
     secs: int | None = None  # Time spent in this bin (seconds)
 
 

--- a/src/intervals_icu_mcp/tools/activities.py
+++ b/src/intervals_icu_mcp/tools/activities.py
@@ -8,11 +8,12 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from .types import IntParam, OptionalIntParam
 
 
 async def get_recent_activities(
-    limit: Annotated[int, "Number of activities to fetch"] = 30,
-    days_back: Annotated[int, "Number of days to look back"] = 30,
+    limit: Annotated[IntParam, "Number of activities to fetch"] = 30,
+    days_back: Annotated[IntParam, "Number of days to look back"] = 30,
     ctx: Context | None = None,
 ) -> str:
     """Get recent activities for the authenticated athlete.
@@ -117,6 +118,28 @@ async def get_activity_details(
     try:
         async with ICUClient(config) as client:
             activity = await client.get_activity(activity_id=activity_id)
+
+            # Detect Strava-sourced stub: numeric ID with no type and no metrics
+            is_strava_stub = (
+                activity.type is None
+                and activity.average_heartrate is None
+                and activity.moving_time is None
+                and not str(activity_id).startswith("i")
+            )
+            if is_strava_stub:
+                return ResponseBuilder.build_response(
+                    data={
+                        "id": activity.id,
+                        "name": activity.name or "Untitled",
+                        "start_date": activity.start_date_local,
+                        "source": "Strava",
+                    },
+                    metadata={
+                        "warning": "Strava-sourced activities are not readable via the Intervals.icu API. "
+                        "Only basic metadata (id, name, date) is available. "
+                        "Use the Intervals.icu web interface to view full details."
+                    },
+                )
 
             activity_data: dict[str, Any] = {
                 "id": activity.id,
@@ -231,7 +254,7 @@ async def get_activity_details(
 
 async def search_activities(
     query: Annotated[str, "Search query (activity name or tag)"],
-    limit: Annotated[int, "Maximum number of results to return"] = 30,
+    limit: Annotated[IntParam, "Maximum number of results to return"] = 30,
     ctx: Context | None = None,
 ) -> str:
     """Search for activities by name or tag.
@@ -305,8 +328,8 @@ async def update_activity(
     activity_type: Annotated[str | None, "Updated activity type (e.g., Ride, Run, Swim)"] = None,
     trainer: Annotated[bool | None, "Mark as trainer/indoor workout"] = None,
     commute: Annotated[bool | None, "Mark as commute"] = None,
-    feel: Annotated[int | None, "How you felt (1-5 scale)"] = None,
-    perceived_exertion: Annotated[int | None, "RPE rating (1-10 scale)"] = None,
+    feel: Annotated[OptionalIntParam, "How you felt (1-5 scale)"] = None,
+    perceived_exertion: Annotated[OptionalIntParam, "RPE rating (1-10 scale)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Update an existing activity's metadata.
@@ -642,7 +665,7 @@ async def download_gpx_file(
 
 async def search_activities_full(
     query: Annotated[str, "Search query (activity name or tag)"],
-    limit: Annotated[int, "Maximum number of results to return"] = 30,
+    limit: Annotated[IntParam, "Maximum number of results to return"] = 30,
     ctx: Context | None = None,
 ) -> str:
     """Search for activities by name or tag, returning complete activity details.
@@ -737,7 +760,7 @@ async def search_activities_full(
 
 async def get_activities_around(
     activity_id: Annotated[str, "Reference activity ID"],
-    count: Annotated[int, "Number of activities before and after"] = 5,
+    count: Annotated[IntParam, "Number of activities before and after"] = 5,
     ctx: Context | None = None,
 ) -> str:
     """Get activities before and after a specific activity for context.

--- a/src/intervals_icu_mcp/tools/activity_analysis.py
+++ b/src/intervals_icu_mcp/tools/activity_analysis.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from .types import IntParam, OptionalIntParam
 
 
 async def get_activity_streams(
@@ -217,6 +218,14 @@ async def get_activity_intervals(
 
 async def get_best_efforts(
     activity_id: Annotated[str, "Activity ID to analyze"],
+    stream: Annotated[
+        str,
+        "Stream to compute best efforts from: 'watts' (power, default), 'heartrate', or 'velocity_smooth' (pace)",
+    ] = "watts",
+    duration: Annotated[
+        int | None,
+        "Duration in seconds to compute best efforts for (optional, default 300 seconds)",
+    ] = None,
     ctx: Context | None = None,
 ) -> str:
     """Get best efforts/peak performances from an activity.
@@ -227,6 +236,8 @@ async def get_best_efforts(
 
     Args:
         activity_id: The unique ID of the activity
+        stream: Stream type to analyze ('watts', 'heartrate', or 'velocity_smooth')
+        duration: Duration in seconds to compute best efforts for (optional, defaults to 300)
 
     Returns:
         JSON string with best efforts data
@@ -236,7 +247,7 @@ async def get_best_efforts(
 
     try:
         async with ICUClient(config) as client:
-            best_efforts = await client.get_best_efforts(activity_id)
+            best_efforts = await client.get_best_efforts(activity_id, stream=stream, duration=duration)
 
             if not best_efforts:
                 return ResponseBuilder.build_response(
@@ -300,10 +311,10 @@ async def get_best_efforts(
 
 
 async def search_intervals(
-    interval_type: Annotated[str | None, "Type of interval to search for"] = None,
-    min_duration: Annotated[int | None, "Minimum duration in seconds"] = None,
-    max_duration: Annotated[int | None, "Maximum duration in seconds"] = None,
-    limit: Annotated[int, "Maximum number of results to return"] = 30,
+    interval_type: Annotated[str, "Type of interval to search for (leave empty for all types)"] = "",
+    min_duration: Annotated[IntParam, "Minimum duration in seconds (0 = no minimum)"] = 0,
+    max_duration: Annotated[IntParam, "Maximum duration in seconds (0 = no maximum)"] = 0,
+    limit: Annotated[IntParam, "Maximum number of results to return"] = 30,
     ctx: Context | None = None,
 ) -> str:
     """Search for similar intervals across all activities.
@@ -327,9 +338,9 @@ async def search_intervals(
     try:
         async with ICUClient(config) as client:
             results = await client.search_intervals(
-                interval_type=interval_type,
-                min_duration=min_duration,
-                max_duration=max_duration,
+                interval_type=interval_type or None,
+                min_duration=min_duration or None,
+                max_duration=max_duration or None,
                 limit=limit,
             )
 

--- a/src/intervals_icu_mcp/tools/athlete.py
+++ b/src/intervals_icu_mcp/tools/athlete.py
@@ -60,17 +60,17 @@ async def get_athlete_profile(
                     sport_data: dict[str, Any] = {}
                     if sport.type:
                         sport_data["type"] = sport.type
+                    elif sport.types:
+                        sport_data["type"] = sport.types[0]
                     if sport.ftp:
                         sport_data["ftp"] = sport.ftp
-                    if sport.fthr:
-                        sport_data["fthr"] = sport.fthr
-                    if sport.pace_threshold:
-                        sport_data["pace_threshold_seconds"] = sport.pace_threshold
-                        minutes = int(sport.pace_threshold // 60)
-                        seconds = int(sport.pace_threshold % 60)
+                    if sport.lthr:
+                        sport_data["fthr"] = sport.lthr
+                    if sport.threshold_pace:
+                        sport_data["pace_threshold_seconds"] = sport.threshold_pace
+                        minutes = int(sport.threshold_pace // 60)
+                        seconds = int(sport.threshold_pace % 60)
                         sport_data["pace_threshold_formatted"] = f"{minutes}:{seconds:02d} /km"
-                    if sport.swim_threshold:
-                        sport_data["swim_threshold"] = sport.swim_threshold
                     sports.append(sport_data)
 
             data: dict[str, Any] = {
@@ -164,7 +164,25 @@ async def get_fitness_summary(
         async with ICUClient(config) as client:
             athlete = await client.get_athlete()
 
-            if athlete.ctl is None and athlete.atl is None:
+            # The athlete endpoint doesn't embed CTL/ATL — fall back to today's wellness record
+            ctl = athlete.ctl
+            atl = athlete.atl
+            tsb = athlete.tsb
+            ramp_rate = athlete.ramp_rate
+
+            if ctl is None and atl is None:
+                from datetime import date
+                today = date.today().isoformat()
+                try:
+                    wellness = await client.get_wellness_for_date(today)
+                    ctl = wellness.ctl
+                    atl = wellness.atl
+                    tsb = wellness.tsb
+                    ramp_rate = wellness.ramp_rate
+                except Exception:
+                    pass
+
+            if ctl is None and atl is None:
                 return ResponseBuilder.build_error_response(
                     "No fitness data available. Complete some activities to build your fitness history.",
                     error_type="no_data",
@@ -172,27 +190,27 @@ async def get_fitness_summary(
 
             # Core metrics
             fitness: dict[str, Any] = {}
-            if athlete.ctl is not None:
+            if ctl is not None:
                 fitness["ctl"] = {
-                    "value": round(athlete.ctl, 1),
+                    "value": round(ctl, 1),
                     "description": "Chronic Training Load (Fitness)",
                     "explanation": "Long-term training load (42-day weighted average)",
                 }
-            if athlete.atl is not None:
+            if atl is not None:
                 fitness["atl"] = {
-                    "value": round(athlete.atl, 1),
+                    "value": round(atl, 1),
                     "description": "Acute Training Load (Fatigue)",
                     "explanation": "Short-term training load (7-day weighted average)",
                 }
-            if athlete.tsb is not None:
+            if tsb is not None:
                 fitness["tsb"] = {
-                    "value": round(athlete.tsb, 1),
+                    "value": round(tsb, 1),
                     "description": "Training Stress Balance (Form)",
                     "explanation": "Fitness - Fatigue",
                 }
-            if athlete.ramp_rate is not None:
+            if ramp_rate is not None:
                 fitness["ramp_rate"] = {
-                    "value": round(athlete.ramp_rate, 1),
+                    "value": round(ramp_rate, 1),
                     "description": "Rate of fitness change (CTL increase per week)",
                 }
 
@@ -200,17 +218,17 @@ async def get_fitness_summary(
             analysis: dict[str, Any] = {}
 
             # TSB interpretation
-            if athlete.tsb is not None:
-                if athlete.tsb > 20:
+            if tsb is not None:
+                if tsb > 20:
                     analysis["form_status"] = "very_fresh"
                     analysis["form_interpretation"] = "You're very fresh - good for racing!"
-                elif athlete.tsb > 5:
+                elif tsb > 5:
                     analysis["form_status"] = "recovered"
                     analysis["form_interpretation"] = "You're recovered and ready for hard training"
-                elif athlete.tsb > -10:
+                elif tsb > -10:
                     analysis["form_status"] = "optimal"
                     analysis["form_interpretation"] = "Optimal zone - productive training possible"
-                elif athlete.tsb > -30:
+                elif tsb > -30:
                     analysis["form_status"] = "fatigued"
                     analysis["form_interpretation"] = (
                         "You're accumulating fatigue - recovery may be needed"
@@ -220,19 +238,19 @@ async def get_fitness_summary(
                     analysis["form_interpretation"] = "High fatigue - prioritize recovery"
 
             # Ramp rate interpretation
-            if athlete.ramp_rate is not None:
-                if athlete.ramp_rate > 8:
+            if ramp_rate is not None:
+                if ramp_rate > 8:
                     analysis["ramp_rate_status"] = "high_risk"
                     analysis["ramp_rate_interpretation"] = "Fitness increasing too fast"
                     analysis["ramp_rate_warning"] = "Reduce training load to avoid overtraining"
-                elif athlete.ramp_rate > 5:
+                elif ramp_rate > 5:
                     analysis["ramp_rate_status"] = "caution"
                     analysis["ramp_rate_interpretation"] = "Fitness increasing rapidly"
                     analysis["ramp_rate_warning"] = "Monitor fatigue and recovery closely"
-                elif athlete.ramp_rate > 0:
+                elif ramp_rate > 0:
                     analysis["ramp_rate_status"] = "good"
                     analysis["ramp_rate_interpretation"] = "Sustainable fitness gain"
-                elif athlete.ramp_rate > -5:
+                elif ramp_rate > -5:
                     analysis["ramp_rate_status"] = "declining"
                     analysis["ramp_rate_interpretation"] = (
                         "Fitness slightly declining (taper/recovery)"
@@ -243,15 +261,15 @@ async def get_fitness_summary(
 
             # Training recommendations
             recommendations: list[str] = []
-            if athlete.tsb is not None and athlete.ramp_rate is not None:
-                if athlete.tsb < -30:
+            if tsb is not None and ramp_rate is not None:
+                if tsb < -30:
                     recommendations.append("Take an easy week or rest days")
                     recommendations.append("Focus on recovery and low-intensity activities")
-                elif athlete.tsb < -10 and athlete.ramp_rate > 5:
+                elif tsb < -10 and ramp_rate > 5:
                     recommendations.append("Balance hard training with recovery")
                     recommendations.append("Consider a recovery week soon")
-                elif athlete.tsb > 5:
-                    if athlete.ramp_rate < 0:
+                elif tsb > 5:
+                    if ramp_rate < 0:
                         recommendations.append("Good time to increase training load")
                         recommendations.append("Consider adding volume or intensity")
                     else:

--- a/src/intervals_icu_mcp/tools/curves.py
+++ b/src/intervals_icu_mcp/tools/curves.py
@@ -8,10 +8,11 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from .types import IntParam, OptionalIntParam
 
 
 async def get_hr_curves(
-    days_back: Annotated[int | None, "Number of days to analyze (optional)"] = None,
+    days_back: Annotated[OptionalIntParam, "Number of days to analyze (optional)"] = None,
     time_period: Annotated[
         str | None,
         "Time period shorthand: 'week', 'month', 'year', 'all' (optional)",
@@ -182,7 +183,7 @@ async def get_hr_curves(
 
 
 async def get_pace_curves(
-    days_back: Annotated[int | None, "Number of days to analyze (optional)"] = None,
+    days_back: Annotated[OptionalIntParam, "Number of days to analyze (optional)"] = None,
     time_period: Annotated[
         str | None,
         "Time period shorthand: 'week', 'month', 'year', 'all' (optional)",

--- a/src/intervals_icu_mcp/tools/event_management.py
+++ b/src/intervals_icu_mcp/tools/event_management.py
@@ -1,6 +1,7 @@
 """Event/calendar management tools for Intervals.icu MCP server."""
 
-from datetime import datetime
+import logging
+import re
 from typing import Annotated, Any
 
 from fastmcp import Context
@@ -8,23 +9,74 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from ..workout_translator import translate_workout
+from .types import IntParam, OptionalIntParam
+
+logger = logging.getLogger(__name__)
+
+
+def _get_sport_type(event_type: str | None) -> str:
+    """Map an Intervals.icu event type string to a translator sport_type.
+
+    Args:
+        event_type: Activity type string from the event (e.g. "Run", "Ride", "Swim").
+
+    Returns:
+        One of "Run", "Ride", or "Swim".
+    """
+    if not event_type:
+        return "Run"
+    t = event_type.lower()
+    if any(word in t for word in ("ride", "cycle", "bike", "cycling", "virtual")):
+        return "Ride"
+    if "swim" in t:
+        return "Swim"
+    return "Run"
+
+
+def normalize_date(date_str: str) -> str:
+    """Normalize date string to Intervals.icu API format (YYYY-MM-DDTHH:MM:SS)."""
+    if not date_str:
+        return date_str
+    if "T" in date_str:
+        if len(date_str) >= 19:
+            return date_str
+        # Partial time like YYYY-MM-DDTHH:MM
+        parts = date_str.split("T")
+        if len(parts[1]) == 5:
+            return f"{date_str}:00"
+        return date_str
+    if len(date_str) == 10:
+        return f"{date_str}T00:00:00"
+    return date_str
+
+
+def validate_date(date_str: str) -> bool:
+    """Return True if date_str matches YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS (optionally HH:MM)."""
+    return bool(re.match(r"^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2})?)?$", date_str))
 
 
 async def create_event(
-    start_date: Annotated[str, "Start date in YYYY-MM-DD format"],
+    start_date: Annotated[str, "Start date. Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS (defaults to 00:00:00 if time omitted)"],
     name: Annotated[str, "Event name"],
     category: Annotated[str, "Event category: WORKOUT, NOTE, RACE, or GOAL"],
-    description: Annotated[str | None, "Event description (optional)"] = None,
+    description: Annotated[str | None, "Event description (optional). If auto_translate is True and this is a WORKOUT, the description will be translated from natural-language FinalSurge format to Intervals.icu structured format automatically."] = None,
     event_type: Annotated[str | None, "Activity type (e.g., Ride, Run, Swim)"] = None,
-    duration_seconds: Annotated[int | None, "Planned duration in seconds"] = None,
+    duration_seconds: Annotated[OptionalIntParam, "Planned duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Planned distance in meters"] = None,
-    training_load: Annotated[int | None, "Planned training load"] = None,
+    training_load: Annotated[OptionalIntParam, "Planned training load"] = None,
+    auto_translate: Annotated[bool, "When True (default), automatically translate natural-language workout descriptions (e.g. FinalSurge format) into Intervals.icu structured format. Only applies to WORKOUT events that have both a description and a duration. Set to False to store the description verbatim."] = True,
     ctx: Context | None = None,
 ) -> str:
     """Create a new calendar event (planned workout, note, race, or goal).
 
     Adds an event to your Intervals.icu calendar. Events can be workouts with
     planned metrics, notes for tracking information, races, or training goals.
+
+    When creating a WORKOUT with a natural-language description (e.g. from FinalSurge),
+    set auto_translate=True (the default) to automatically convert the description into
+    Intervals.icu's structured workout format. The response includes translation metadata
+    so you can see whether the description was changed.
 
     Args:
         start_date: Date in ISO-8601 format (YYYY-MM-DD)
@@ -35,6 +87,7 @@ async def create_event(
         duration_seconds: Planned duration for workouts
         distance_meters: Planned distance for workouts
         training_load: Planned training load for workouts
+        auto_translate: Translate natural-language descriptions to ICU format (default True)
 
     Returns:
         JSON string with created event data
@@ -51,13 +104,33 @@ async def create_event(
         )
 
     # Validate date format
-    try:
-        datetime.strptime(start_date, "%Y-%m-%d")
-    except ValueError:
+    if not validate_date(start_date):
         return ResponseBuilder.build_error_response(
-            "Invalid date format. Please use YYYY-MM-DD format.",
+            "Invalid date format. Use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS.",
             error_type="validation_error",
         )
+
+    start_date = normalize_date(start_date)
+
+    # Auto-translate description for WORKOUT events when conditions are met
+    translation_meta: dict[str, Any] = {}
+    if (
+        auto_translate
+        and description
+        and duration_seconds
+        and category.upper() == "WORKOUT"
+    ):
+        sport_type = _get_sport_type(event_type)
+        translated = translate_workout(description, int(duration_seconds), sport_type)
+        if translated != description:
+            translation_meta = {
+                "description_translated": True,
+                "original_description": description,
+            }
+            description = translated
+            logger.info("Auto-translated workout description for event '%s'", name)
+        else:
+            translation_meta = {"description_translated": False}
 
     try:
         # Build event data
@@ -102,7 +175,10 @@ async def create_event(
             return ResponseBuilder.build_response(
                 data=event_result,
                 query_type="create_event",
-                metadata={"message": f"Successfully created {category.lower()}: {name}"},
+                metadata={
+                    "message": f"Successfully created {category.lower()}: {name}",
+                    **translation_meta,
+                },
             )
 
     except ICUAPIError as e:
@@ -114,14 +190,14 @@ async def create_event(
 
 
 async def update_event(
-    event_id: Annotated[int, "Event ID to update"],
+    event_id: Annotated[IntParam, "Event ID to update"],
     name: Annotated[str | None, "Updated event name"] = None,
     description: Annotated[str | None, "Updated description"] = None,
     start_date: Annotated[str | None, "Updated start date (YYYY-MM-DD)"] = None,
     event_type: Annotated[str | None, "Updated activity type"] = None,
-    duration_seconds: Annotated[int | None, "Updated duration in seconds"] = None,
+    duration_seconds: Annotated[OptionalIntParam, "Updated duration in seconds"] = None,
     distance_meters: Annotated[float | None, "Updated distance in meters"] = None,
-    training_load: Annotated[int | None, "Updated training load"] = None,
+    training_load: Annotated[OptionalIntParam, "Updated training load"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Update an existing calendar event.
@@ -147,13 +223,12 @@ async def update_event(
 
     # Validate date format if provided
     if start_date:
-        try:
-            datetime.strptime(start_date, "%Y-%m-%d")
-        except ValueError:
+        if not validate_date(start_date):
             return ResponseBuilder.build_error_response(
-                "Invalid date format. Please use YYYY-MM-DD format.",
+                "Invalid date format. Use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS.",
                 error_type="validation_error",
             )
+        start_date = normalize_date(start_date)
 
     try:
         # Build update data (only include provided fields)
@@ -216,7 +291,7 @@ async def update_event(
 
 
 async def delete_event(
-    event_id: Annotated[int, "Event ID to delete"],
+    event_id: Annotated[IntParam, "Event ID to delete"],
     ctx: Context | None = None,
 ) -> str:
     """Delete a calendar event.
@@ -261,6 +336,10 @@ async def bulk_create_events(
         str,
         "JSON string containing array of events. Each event should have: start_date_local, name, category, and optional fields like description, type, moving_time, distance, icu_training_load",
     ],
+    auto_translate: Annotated[
+        bool,
+        "When True (default), automatically translate natural-language workout descriptions into Intervals.icu structured format for each WORKOUT event that has both a description and a moving_time. Set to False to store descriptions verbatim.",
+    ] = True,
     ctx: Context | None = None,
 ) -> str:
     """Create multiple calendar events in a single operation.
@@ -268,8 +347,14 @@ async def bulk_create_events(
     This is more efficient than creating events one at a time. Provide a JSON array
     of event objects, each with the same structure as create_event.
 
+    When auto_translate is True (the default), each WORKOUT event whose description
+    looks like a natural-language format (e.g. FinalSurge) will have its description
+    automatically converted to Intervals.icu structured format before creation.
+    The response includes a translated_count so you can see how many were changed.
+
     Args:
         events: JSON array of event objects to create
+        auto_translate: Translate natural-language descriptions to ICU format (default True)
 
     Returns:
         JSON string with created events
@@ -322,14 +407,33 @@ async def bulk_create_events(
             # Normalize category to uppercase
             event_data["category"] = event_data["category"].upper()
 
-            # Validate date format
-            try:
-                datetime.strptime(event_data["start_date_local"], "%Y-%m-%d")
-            except ValueError:
+            # Validate and normalize date format
+            if not validate_date(event_data["start_date_local"]):
                 return ResponseBuilder.build_error_response(
-                    f"Event {i}: Invalid date format. Please use YYYY-MM-DD format.",
+                    f"Event {i}: Invalid date format. Use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS.",
                     error_type="validation_error",
                 )
+            event_data["start_date_local"] = normalize_date(event_data["start_date_local"])
+
+        # Auto-translate descriptions for eligible WORKOUT events
+        translated_count = 0
+        if auto_translate:
+            for event_data in events_data:
+                if event_data.get("category") != "WORKOUT":
+                    continue
+                desc = event_data.get("description")
+                duration = event_data.get("moving_time")
+                if not desc or not duration:
+                    continue
+                sport_type = _get_sport_type(event_data.get("type"))
+                translated = translate_workout(desc, int(duration), sport_type)
+                if translated != desc:
+                    event_data["description"] = translated
+                    translated_count += 1
+                    logger.info(
+                        "Auto-translated workout description for event '%s'",
+                        event_data.get("name", "<unnamed>"),
+                    )
 
         async with ICUClient(config) as client:
             created_events = await client.bulk_create_events(events_data)
@@ -362,6 +466,7 @@ async def bulk_create_events(
                 metadata={
                     "message": f"Successfully created {len(created_events)} events",
                     "count": len(created_events),
+                    "translated_count": translated_count,
                 },
             )
 
@@ -433,7 +538,7 @@ async def bulk_delete_events(
 
 
 async def duplicate_event(
-    event_id: Annotated[int, "Event ID to duplicate"],
+    event_id: Annotated[IntParam, "Event ID to duplicate"],
     new_date: Annotated[str, "New date for the duplicated event (YYYY-MM-DD format)"],
     ctx: Context | None = None,
 ) -> str:
@@ -453,13 +558,12 @@ async def duplicate_event(
     config: ICUConfig = ctx.get_state("config")
 
     # Validate date format
-    try:
-        datetime.strptime(new_date, "%Y-%m-%d")
-    except ValueError:
+    if not validate_date(new_date):
         return ResponseBuilder.build_error_response(
-            "Invalid date format. Please use YYYY-MM-DD format.",
+            "Invalid date format. Use YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS.",
             error_type="validation_error",
         )
+    new_date = normalize_date(new_date)
 
     try:
         async with ICUClient(config) as client:

--- a/src/intervals_icu_mcp/tools/events.py
+++ b/src/intervals_icu_mcp/tools/events.py
@@ -8,11 +8,12 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from .types import IntParam, OptionalIntParam
 
 
 async def get_calendar_events(
-    days_ahead: Annotated[int, "Number of days to look ahead"] = 7,
-    days_back: Annotated[int, "Number of days to look back"] = 0,
+    days_ahead: Annotated[IntParam, "Number of days to look ahead"] = 7,
+    days_back: Annotated[IntParam, "Number of days to look back"] = 0,
     ctx: Context | None = None,
 ) -> str:
     """Get planned events and workouts from the calendar.
@@ -67,7 +68,7 @@ async def get_calendar_events(
                     events_by_date[date] = []
 
                 # Determine relative timing
-                date_obj = datetime.strptime(date, "%Y-%m-%d").date()
+                date_obj = datetime.strptime(date.split("T")[0], "%Y-%m-%d").date()
                 today = datetime.now().date()
 
                 if date_obj == today:
@@ -145,7 +146,7 @@ async def get_calendar_events(
 
 
 async def get_upcoming_workouts(
-    limit: Annotated[int, "Maximum number of workouts to return"] = 7,
+    limit: Annotated[IntParam, "Maximum number of workouts to return"] = 7,
     ctx: Context | None = None,
 ) -> str:
     """Get upcoming planned workouts from the calendar.
@@ -189,7 +190,7 @@ async def get_upcoming_workouts(
 
             workouts_data: list[dict[str, Any]] = []
             for workout in workouts:
-                date_obj = datetime.strptime(workout.start_date_local, "%Y-%m-%d").date()
+                date_obj = datetime.strptime(workout.start_date_local.split("T")[0], "%Y-%m-%d").date()
                 today = datetime.now().date()
 
                 if date_obj == today:
@@ -251,7 +252,7 @@ async def get_upcoming_workouts(
 
 
 async def get_event(
-    event_id: Annotated[int, "Event ID to retrieve"],
+    event_id: Annotated[IntParam, "Event ID to retrieve"],
     ctx: Context | None = None,
 ) -> str:
     """Get detailed information for a specific calendar event.

--- a/src/intervals_icu_mcp/tools/gear.py
+++ b/src/intervals_icu_mcp/tools/gear.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from ..auth import load_config, validate_credentials
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from .types import IntParam, OptionalIntParam
 
 
 async def get_gear_list(
@@ -310,7 +311,7 @@ async def create_gear_reminder(
     distance_alert: Annotated[
         float | None, "Alert every N kilometers (e.g., 500 for every 500km)"
     ] = None,
-    time_alert: Annotated[int | None, "Alert every N hours (e.g., 100 for every 100 hours)"] = None,
+    time_alert: Annotated[OptionalIntParam, "Alert every N hours (e.g., 100 for every 100 hours)"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Create a maintenance reminder for a gear item.
@@ -380,10 +381,10 @@ async def create_gear_reminder(
 
 async def update_gear_reminder(
     gear_id: Annotated[str, "ID of the gear item"],
-    reminder_id: Annotated[int, "ID of the reminder to update"],
+    reminder_id: Annotated[IntParam, "ID of the reminder to update"],
     text: Annotated[str | None, "Updated reminder text"] = None,
     distance_alert: Annotated[float | None, "Updated distance alert in kilometers"] = None,
-    time_alert: Annotated[int | None, "Updated time alert in hours"] = None,
+    time_alert: Annotated[OptionalIntParam, "Updated time alert in hours"] = None,
     ctx: Context | None = None,
 ) -> str:
     """Update an existing gear maintenance reminder.

--- a/src/intervals_icu_mcp/tools/performance.py
+++ b/src/intervals_icu_mcp/tools/performance.py
@@ -8,14 +8,19 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from .types import IntParam, OptionalIntParam
 
 
 async def get_power_curves(
-    days_back: Annotated[int | None, "Number of days to analyze (optional)"] = None,
+    days_back: Annotated[OptionalIntParam, "Number of days to analyze (optional)"] = None,
     time_period: Annotated[
         str | None,
         "Time period shorthand: 'week', 'month', 'year', 'all' (optional)",
     ] = None,
+    activity_type: Annotated[
+        str,
+        "Activity type to analyze: 'Ride' (default), 'VirtualRide', 'Run', 'VirtualRun', etc.",
+    ] = "Ride",
     ctx: Context | None = None,
 ) -> str:
     """Get power curve data showing best efforts for various durations.
@@ -30,6 +35,7 @@ async def get_power_curves(
         days_back: Number of days to analyze (overrides time_period)
         time_period: Time period shorthand - 'week' (7 days), 'month' (30 days),
                      'year' (365 days), 'all' (all time). Default is 90 days.
+        activity_type: Activity type to filter by (default 'Ride')
 
     Returns:
         JSON string with power curve data
@@ -71,7 +77,7 @@ async def get_power_curves(
             period_label = "90_days"
 
         async with ICUClient(config) as client:
-            power_curve = await client.get_power_curves(oldest=oldest)
+            power_curve = await client.get_power_curves(oldest=oldest, activity_type=activity_type)
 
             if not power_curve.data or len(power_curve.data) == 0:
                 return ResponseBuilder.build_response(

--- a/src/intervals_icu_mcp/tools/sport_settings.py
+++ b/src/intervals_icu_mcp/tools/sport_settings.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from ..auth import load_config, validate_credentials
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from .types import IntParam, OptionalIntParam
 
 
 async def get_sport_settings(
@@ -37,7 +38,7 @@ async def get_sport_settings(
             for settings in settings_list:
                 sport_info: dict[str, Any] = {
                     "id": settings.id,
-                    "type": settings.type,
+                    "types": settings.types,
                 }
 
                 # Power settings (cycling)
@@ -45,23 +46,16 @@ async def get_sport_settings(
                     sport_info["ftp_watts"] = settings.ftp
 
                 # Heart rate settings
-                if settings.fthr is not None:
-                    sport_info["fthr_bpm"] = settings.fthr
+                if settings.lthr is not None:
+                    sport_info["lthr_bpm"] = settings.lthr
 
                 # Pace settings (running/swimming)
-                if settings.pace_threshold is not None:
-                    # Convert to min:sec per km
-                    pace_secs = settings.pace_threshold * 60
+                if settings.threshold_pace is not None:
+                    pace_secs = settings.threshold_pace * 60
                     minutes = int(pace_secs // 60)
                     seconds = int(pace_secs % 60)
-                    sport_info["pace_threshold"] = f"{minutes}:{seconds:02d} /km"
-
-                if settings.swim_threshold is not None:
-                    # Convert to min:sec per 100m
-                    swim_secs = settings.swim_threshold * 60
-                    minutes = int(swim_secs // 60)
-                    seconds = int(swim_secs % 60)
-                    sport_info["swim_threshold"] = f"{minutes}:{seconds:02d} /100m"
+                    unit = "/100m" if settings.pace_units == "SECS_100M" else "/km"
+                    sport_info["threshold_pace"] = f"{minutes}:{seconds:02d} {unit}"
 
                 settings_data.append(sport_info)
 
@@ -77,9 +71,9 @@ async def get_sport_settings(
 
 
 async def update_sport_settings(
-    sport_id: Annotated[int, "ID of the sport settings to update"],
-    ftp: Annotated[int | None, "Functional Threshold Power in watts (for cycling)"] = None,
-    fthr: Annotated[int | None, "Functional Threshold Heart Rate in bpm"] = None,
+    sport_id: Annotated[IntParam, "ID of the sport settings to update"],
+    ftp: Annotated[OptionalIntParam, "Functional Threshold Power in watts (for cycling)"] = None,
+    fthr: Annotated[OptionalIntParam, "Functional Threshold Heart Rate in bpm"] = None,
     pace_threshold: Annotated[
         float | None, "Threshold pace in min/km (e.g., 4.5 for 4:30/km)"
     ] = None,
@@ -128,23 +122,19 @@ async def update_sport_settings(
 
             result: dict[str, Any] = {
                 "id": settings.id,
-                "type": settings.type,
+                "types": settings.types,
             }
 
             if settings.ftp is not None:
                 result["ftp_watts"] = settings.ftp
-            if settings.fthr is not None:
-                result["fthr_bpm"] = settings.fthr
-            if settings.pace_threshold is not None:
-                pace_secs = settings.pace_threshold * 60
+            if settings.lthr is not None:
+                result["lthr_bpm"] = settings.lthr
+            if settings.threshold_pace is not None:
+                pace_secs = settings.threshold_pace * 60
                 minutes = int(pace_secs // 60)
                 seconds = int(pace_secs % 60)
-                result["pace_threshold"] = f"{minutes}:{seconds:02d} /km"
-            if settings.swim_threshold is not None:
-                swim_secs = settings.swim_threshold * 60
-                minutes = int(swim_secs // 60)
-                seconds = int(swim_secs % 60)
-                result["swim_threshold"] = f"{minutes}:{seconds:02d} /100m"
+                unit = "/100m" if settings.pace_units == "SECS_100M" else "/km"
+                result["threshold_pace"] = f"{minutes}:{seconds:02d} {unit}"
 
             return ResponseBuilder.build_response(
                 result,
@@ -161,7 +151,7 @@ async def update_sport_settings(
 
 
 async def apply_sport_settings(
-    sport_id: Annotated[int, "ID of the sport settings to apply"],
+    sport_id: Annotated[IntParam, "ID of the sport settings to apply"],
     oldest_date: Annotated[
         str | None, "Oldest date to apply settings to (YYYY-MM-DD format)"
     ] = None,
@@ -205,8 +195,8 @@ async def apply_sport_settings(
 
 async def create_sport_settings(
     sport_type: Annotated[str, "Type of sport (e.g., 'Ride', 'Run', 'Swim')"],
-    ftp: Annotated[int | None, "Functional Threshold Power in watts (for cycling)"] = None,
-    fthr: Annotated[int | None, "Functional Threshold Heart Rate in bpm"] = None,
+    ftp: Annotated[OptionalIntParam, "Functional Threshold Power in watts (for cycling)"] = None,
+    fthr: Annotated[OptionalIntParam, "Functional Threshold Heart Rate in bpm"] = None,
     pace_threshold: Annotated[
         float | None, "Threshold pace in min/km (e.g., 4.5 for 4:30/km)"
     ] = None,
@@ -250,23 +240,19 @@ async def create_sport_settings(
 
             result: dict[str, Any] = {
                 "id": settings.id,
-                "type": settings.type,
+                "types": settings.types,
             }
 
             if settings.ftp is not None:
                 result["ftp_watts"] = settings.ftp
-            if settings.fthr is not None:
-                result["fthr_bpm"] = settings.fthr
-            if settings.pace_threshold is not None:
-                pace_secs = settings.pace_threshold * 60
+            if settings.lthr is not None:
+                result["lthr_bpm"] = settings.lthr
+            if settings.threshold_pace is not None:
+                pace_secs = settings.threshold_pace * 60
                 minutes = int(pace_secs // 60)
                 seconds = int(pace_secs % 60)
-                result["pace_threshold"] = f"{minutes}:{seconds:02d} /km"
-            if settings.swim_threshold is not None:
-                swim_secs = settings.swim_threshold * 60
-                minutes = int(swim_secs // 60)
-                seconds = int(swim_secs % 60)
-                result["swim_threshold"] = f"{minutes}:{seconds:02d} /100m"
+                unit = "/100m" if settings.pace_units == "SECS_100M" else "/km"
+                result["threshold_pace"] = f"{minutes}:{seconds:02d} {unit}"
 
             return ResponseBuilder.build_response(
                 result,
@@ -283,7 +269,7 @@ async def create_sport_settings(
 
 
 async def delete_sport_settings(
-    sport_id: Annotated[int, "ID of the sport settings to delete"],
+    sport_id: Annotated[IntParam, "ID of the sport settings to delete"],
     ctx: Context | None = None,
 ) -> str:
     """Delete sport-specific settings.

--- a/src/intervals_icu_mcp/tools/types.py
+++ b/src/intervals_icu_mcp/tools/types.py
@@ -1,0 +1,38 @@
+"""Shared parameter types for MCP tools.
+
+The MCP client (Claude Code) encodes all XML parameter values as strings before
+sending them to the server. These types accept strings and coerce to the target
+Python type so tools work correctly with explicitly passed values.
+"""
+
+from typing import Annotated, Any
+
+from pydantic import BeforeValidator
+from pydantic.json_schema import WithJsonSchema
+
+
+def _to_int(v: Any) -> int:
+    if isinstance(v, str):
+        return int(v)
+    return int(v)
+
+
+def _to_optional_int(v: Any) -> int | None:
+    if v is None or v == "":
+        return None
+    return _to_int(v)
+
+
+# Use these in place of bare `int` / `int | None` in Annotated tool parameters.
+# They accept numeric strings ("60") while keeping {type: integer} in the JSON schema.
+IntParam = Annotated[
+    int,
+    BeforeValidator(_to_int),
+    WithJsonSchema({"type": ["integer", "string"]}),
+]
+
+OptionalIntParam = Annotated[
+    int | None,
+    BeforeValidator(_to_optional_int),
+    WithJsonSchema({"anyOf": [{"type": ["integer", "string"]}, {"type": "null"}]}),
+]

--- a/src/intervals_icu_mcp/tools/wellness.py
+++ b/src/intervals_icu_mcp/tools/wellness.py
@@ -8,10 +8,11 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from .types import IntParam, OptionalIntParam
 
 
 async def get_wellness_data(
-    days_back: Annotated[int, "Number of days to look back"] = 7,
+    days_back: Annotated[IntParam, "Number of days to look back"] = 7,
     ctx: Context | None = None,
 ) -> str:
     """Get wellness data for recent days.
@@ -340,15 +341,15 @@ async def get_wellness_for_date(
 async def update_wellness(
     date: Annotated[str, "Date in YYYY-MM-DD format"],
     weight: Annotated[float | None, "Weight in kg"] = None,
-    resting_hr: Annotated[int | None, "Resting heart rate in bpm"] = None,
+    resting_hr: Annotated[OptionalIntParam, "Resting heart rate in bpm"] = None,
     hrv: Annotated[float | None, "HRV (rMSSD) value"] = None,
-    sleep_secs: Annotated[int | None, "Sleep duration in seconds"] = None,
-    sleep_quality: Annotated[int | None, "Sleep quality (1-5 scale)"] = None,
-    fatigue: Annotated[int | None, "Fatigue level (1-5 scale)"] = None,
-    soreness: Annotated[int | None, "Soreness level (1-5 scale)"] = None,
-    stress: Annotated[int | None, "Stress level (1-5 scale)"] = None,
-    mood: Annotated[int | None, "Mood level (1-5 scale)"] = None,
-    motivation: Annotated[int | None, "Motivation level (1-5 scale)"] = None,
+    sleep_secs: Annotated[OptionalIntParam, "Sleep duration in seconds"] = None,
+    sleep_quality: Annotated[OptionalIntParam, "Sleep quality (1-5 scale)"] = None,
+    fatigue: Annotated[OptionalIntParam, "Fatigue level (1-5 scale)"] = None,
+    soreness: Annotated[OptionalIntParam, "Soreness level (1-5 scale)"] = None,
+    stress: Annotated[OptionalIntParam, "Stress level (1-5 scale)"] = None,
+    mood: Annotated[OptionalIntParam, "Mood level (1-5 scale)"] = None,
+    motivation: Annotated[OptionalIntParam, "Motivation level (1-5 scale)"] = None,
     readiness: Annotated[float | None, "Readiness score (0-100)"] = None,
     comments: Annotated[str | None, "Comments or notes"] = None,
     ctx: Context | None = None,

--- a/src/intervals_icu_mcp/tools/workout_library.py
+++ b/src/intervals_icu_mcp/tools/workout_library.py
@@ -7,6 +7,7 @@ from fastmcp import Context
 from ..auth import ICUConfig
 from ..client import ICUAPIError, ICUClient
 from ..response_builder import ResponseBuilder
+from .types import IntParam, OptionalIntParam
 
 
 async def get_workout_library(
@@ -92,7 +93,7 @@ async def get_workout_library(
 
 
 async def get_workouts_in_folder(
-    folder_id: Annotated[int, "Folder ID to get workouts from"],
+    folder_id: Annotated[IntParam, "Folder ID to get workouts from"],
     ctx: Context | None = None,
 ) -> str:
     """Get all workouts in a specific folder or training plan.

--- a/src/intervals_icu_mcp/workout_translator.py
+++ b/src/intervals_icu_mcp/workout_translator.py
@@ -1,0 +1,914 @@
+"""Translate FinalSurge descriptive workout text into Intervals.icu plain-text format."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Intensity mapping: FinalSurge terms → Intervals.icu format
+# ---------------------------------------------------------------------------
+
+INTENSITY_MAP: dict[str, str] = {
+    # Recovery-qualified phrases (must appear before shorter "easy jog" key so
+    # longer-match-first sorting resolves them to z1, not z2).
+    "easy jog rest": "z1 pace",
+    "walk/easy jog rest": "z1 pace",
+    "easy rest": "z1 pace",
+    "walk rest": "z1 pace",
+    # Standard intensity terms
+    "easy jog": "z2 pace",
+    "easy run": "z2 pace",
+    "easy": "z2 pace",
+    "recovery jog": "z1 pace",
+    "jog rest": "z1 pace",
+    "recovery": "z1 pace",
+    "jog": "z2 pace",
+    "walk": "z1 pace",
+    "rest": "z1 pace",
+    "tempo": "z3 pace",
+    "threshold": "z4 pace",
+    "@threshold": "z4 pace",
+    "hmp": "z4 pace",
+    "@hmp": "z4 pace",
+    "half marathon pace": "z4 pace",
+    "marathon pace": "z3 pace",
+    "@mp": "z3 pace",
+    "mp": "z3 pace",
+    "stride": "z5 pace",
+    "strides": "z5 pace",
+    "pickup": "z5 pace",
+    "pickups": "z5 pace",
+    "pick-up": "z5 pace",
+    "pick-ups": "z5 pace",
+    "fast": "z5 pace",
+    "sprint": "z6 pace",
+    # on/off keywords (e.g. "30s on / 2 mins off")
+    "on": "z5 pace",
+    "off": "z1 pace",
+    # Zone pass-through
+    "z1": "z1 pace",
+    "z2": "z2 pace",
+    "z3": "z3 pace",
+    "z4": "z4 pace",
+    "z5": "z5 pace",
+    "z6": "z6 pace",
+    # Zone with dash notation
+    "z1-z2": "z2 pace",
+    "z2-z3": "z2 pace",
+}
+
+
+# ---------------------------------------------------------------------------
+# Meters vs. minutes disambiguation (Phase 5a — P1)
+# ---------------------------------------------------------------------------
+
+# Common track/road distances that would never be valid minute counts.
+_METER_DISTANCES: frozenset[int] = frozenset(
+    {100, 150, 200, 300, 400, 600, 800, 1000, 1200, 1500, 1600, 3000, 5000}
+)
+# Any Xm where X > 90 is not a realistic workout-step duration in minutes.
+_MINUTE_THRESHOLD = 90
+
+
+def _is_meters_not_minutes(value: float) -> bool:
+    """Return True if *value* almost certainly represents meters, not minutes."""
+    v = int(value)
+    return v in _METER_DISTANCES or v > _MINUTE_THRESHOLD
+
+
+def _map_intensity(raw: str, sport_type: str = "Run") -> str:
+    """Return Intervals.icu intensity string for a raw FinalSurge intensity token."""
+    key = raw.strip().lower()
+    if key in INTENSITY_MAP:
+        return INTENSITY_MAP[key]
+    # Z1-Z5 pattern with capitalisation
+    zm = re.fullmatch(r"z(\d)(?:-z\d)?", key)
+    if zm:
+        return f"z{zm.group(1)} pace"
+    return "z2 pace"  # conservative default
+
+
+# ---------------------------------------------------------------------------
+# Duration helpers
+# ---------------------------------------------------------------------------
+
+
+def _seconds_to_icu(total_seconds: int) -> str:
+    """Convert a duration in seconds to Intervals.icu format (e.g. 1m30s, 45s, 10m)."""
+    if total_seconds <= 0:
+        return "0s"
+    hours = total_seconds // 3600
+    remainder = total_seconds % 3600
+    minutes = remainder // 60
+    seconds = remainder % 60
+    parts: list[str] = []
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes:
+        parts.append(f"{minutes}m")
+    if seconds:
+        parts.append(f"{seconds}s")
+    return "".join(parts) if parts else "0s"
+
+
+def _parse_duration_to_seconds(text: str) -> int | None:
+    """Parse a duration string like '10:00', '10min', '15s', '1m30s' → seconds."""
+    text = text.strip()
+    # MM:SS or H:MM:SS
+    colon_match = re.fullmatch(r"(?:(\d+):)?(\d+):(\d+)", text)
+    if colon_match:
+        h = int(colon_match.group(1) or 0)
+        m = int(colon_match.group(2))
+        s = int(colon_match.group(3))
+        return h * 3600 + m * 60 + s
+    # 1h2m30s style
+    compound = re.fullmatch(
+        r"(?:(\d+)h)?(?:(\d+)m(?!i))?(?:(\d+)s)?",
+        text,
+        re.IGNORECASE,
+    )
+    if compound and compound.group(0):
+        h = int(compound.group(1) or 0)
+        m = int(compound.group(2) or 0)
+        s = int(compound.group(3) or 0)
+        total = h * 3600 + m * 60 + s
+        if total > 0:
+            return total
+    # plain number + unit
+    plain = re.fullmatch(r"(\d+(?:\.\d+)?)\s*(min|mins|minutes?|s|sec|secs|seconds?|h|hrs?|hours?)", text, re.IGNORECASE)
+    if plain:
+        val = float(plain.group(1))
+        unit = plain.group(2).lower()
+        if unit.startswith("h"):
+            return int(val * 3600)
+        if unit.startswith("m"):
+            return int(val * 60)
+        return int(val)
+    # bare seconds e.g. "15" (assume seconds when small)
+    bare = re.fullmatch(r"(\d+)", text)
+    if bare:
+        return int(bare.group(1))
+    return None
+
+
+def _resolve_range(low: float, high: float, strategy: str = "midpoint") -> float:
+    """Resolve a numeric range to a single value."""
+    if strategy == "midpoint_rounded_down":
+        return float(int((low + high) / 2))
+    # midpoint
+    return (low + high) / 2
+
+
+# ---------------------------------------------------------------------------
+# Strides / pickups template
+# ---------------------------------------------------------------------------
+
+# Detects strides/pickups anywhere in description (case-insensitive whole word).
+_STRIDES_RE = re.compile(r"\b(stride|strides|pickup|pick-up|pickups|pick-ups)\b", re.IGNORECASE)
+
+# Guard: if an explicit zone or "@Stride/Fast" annotation is already present,
+# the paren-form parser already handled it — don't override with the template.
+_EXPLICIT_ZONE_RE = re.compile(r"\b[Zz][1-6]\b", re.IGNORECASE)
+
+# Standard strides template: 5 reps × (15 s hard + 1 m 45 s recovery).
+_STRIDES_REPS = 5
+_STRIDES_WORK_SECS = 15   # 15 s @ z5
+_STRIDES_REST_SECS = 105  # 1 m 45 s @ z1  (2-minute gap between strides)
+
+
+def _build_strides(duration_seconds: int) -> str:
+    """
+    Emit the standard strides block: easy base run + 5 × (15 s z5 / 1m45s z1).
+
+    The total interval time (5 × 2 min = 10 min) is subtracted from the total
+    workout duration to size the base easy run.
+    """
+    interval_secs = _STRIDES_REPS * (_STRIDES_WORK_SECS + _STRIDES_REST_SECS)
+    base_secs = max(0, duration_seconds - interval_secs)
+    lines: list[str] = []
+    if base_secs > 60:
+        lines.append(f"- {_seconds_to_icu(base_secs)} z2 pace")
+        lines.append("")
+    lines.append(f"{_STRIDES_REPS}x")
+    lines.append(f"- {_seconds_to_icu(_STRIDES_WORK_SECS)} z5 pace")
+    lines.append(f"- {_seconds_to_icu(_STRIDES_REST_SECS)} z1 pace")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main parser
+# ---------------------------------------------------------------------------
+
+
+class WorkoutTranslationError(Exception):
+    """Raised when translation cannot proceed."""
+
+
+def _extract_repeat_block(description: str) -> tuple[int, str, list[str]] | None:
+    """
+    Find the first "Nx(...)" or "N-Mx(...)" pattern in the description.
+
+    Returns (reps, inner_text, remaining_tokens_outside_parens) or None.
+    remaining_tokens is a list of text segments that were outside the parentheses block.
+    """
+    # Pattern: optional range N-M or single N followed by 'x' then '(' ... ')'
+    # Allow one level of nested parens (e.g. "Fast (Z5)") inside the block.
+    pattern = re.compile(
+        r"(\d+)(?:-(\d+))?x\s*"
+        r"(\((?:[^()]*|\([^()]*\))*\))",
+        re.IGNORECASE,
+    )
+    m = pattern.search(description)
+    if not m:
+        return None
+    low = float(m.group(1))
+    high = float(m.group(2)) if m.group(2) else low
+    reps = int(_resolve_range(low, high, "midpoint_rounded_down"))
+    # Strip outer parens to get inner content
+    inner = m.group(3)[1:-1]
+    # Split description around the matched block
+    before = description[: m.start()]
+    after = description[m.end() :]
+    return reps, inner, [before, after]
+
+
+def _parse_inner_steps(inner: str, sport_type: str) -> list[tuple[int, str]]:
+    """
+    Parse the inside of a repeat block into (duration_seconds, intensity) pairs.
+
+    Scans sequentially for all duration tokens; each token's associated intensity
+    is the text between it and the next token.  This handles both:
+      - slash-separated segments: ``15-20s @ Stride / Full recovery easy jog``
+      - adjacent segments:        ``10:00 @ HMP (Z4) 5:00 Walk / Easy Jog``
+    """
+    # Normalise separators so "/" doesn't confuse duration scanning
+    text = re.sub(r"[/,\n]+", " ", inner)
+
+    # Pattern that matches (in priority order):
+    #   1. range duration:  15-20s, 10-15m
+    #   2. colon duration:  10:00, 5:00
+    #   3. plain duration:  17s, 10m, 1h
+    token_pat = re.compile(
+        r"\b(\d+)\s*-\s*(\d+)\s*(s|sec|secs|seconds?|m(?!i)|min|mins|minutes?|h|hrs?)\b"
+        r"|\b(\d+):(\d{2})\b"
+        r"|\b(\d+(?:\.\d+)?)\s*(s|sec|secs|seconds?|m(?!i)|min|mins|minutes?|h|hrs?|hours?)\b",
+        re.IGNORECASE,
+    )
+
+    matches = list(token_pat.finditer(text))
+    if not matches:
+        return []
+
+    steps: list[tuple[int, str]] = []
+    for i, m in enumerate(matches):
+        # --- parse duration ---
+        if m.group(1) and m.group(2):  # range
+            low, high = float(m.group(1)), float(m.group(2))
+            mid = _resolve_range(low, high, "midpoint")
+            unit = m.group(3).lower()
+            if unit.startswith("h"):
+                dur = int(mid * 3600)
+            elif unit.startswith("m"):
+                # "m", "min", "mins", "minutes" all mean minutes; "miles" is already
+                # excluded by the m(?!i) negative lookahead in the token pattern.
+                if _is_meters_not_minutes(low) or _is_meters_not_minutes(high):
+                    raise WorkoutTranslationError(
+                        f"Distance-based range: {int(low)}-{int(high)}m detected."
+                    )
+                dur = int(mid * 60)
+            else:
+                dur = int(mid)
+        elif m.group(4) and m.group(5):  # MM:SS
+            dur = int(m.group(4)) * 60 + int(m.group(5))
+        else:  # plain
+            val = float(m.group(6))
+            unit = m.group(7).lower()
+            if unit.startswith("h"):
+                dur = int(val * 3600)
+            elif unit.startswith("m"):
+                # "m", "min", "mins", "minutes" all mean minutes; "miles" excluded by regex.
+                if _is_meters_not_minutes(val):
+                    raise WorkoutTranslationError(
+                        f"Distance-based step: {int(val)}m detected."
+                    )
+                dur = int(val * 60)
+            else:
+                dur = int(val)
+
+        # --- intensity: text from end of this match to start of next ---
+        intensity_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        intensity_text = text[m.end() : intensity_end].strip()
+        # Zone hint in parentheses takes priority
+        zone_m = re.search(r"\(\s*(Z\d(?:-Z\d)?)\s*\)", intensity_text, re.IGNORECASE)
+        if zone_m:
+            intensity = _map_intensity(zone_m.group(1), sport_type)
+        else:
+            intensity = _identify_intensity(intensity_text, sport_type)
+
+        steps.append((dur, intensity))
+
+    return steps
+
+
+def _parse_step_fragment(fragment: str, sport_type: str) -> tuple[int | None, str]:
+    """
+    Extract (duration_seconds, intensity) from a single step fragment like
+    '15-20s @ Stride / Fast (Z5)' or '5:00 Walk / Easy Jog recovery'.
+    """
+    # Normalise '@' separator
+    fragment = fragment.replace("@", " ").strip()
+
+    # Remove parenthetical zone annotations like "(Z5)" that follow intensity words
+    # but keep the zone info to help mapping
+    zone_in_parens = re.search(r"\(\s*(Z\d(?:-Z\d)?)\s*\)", fragment, re.IGNORECASE)
+    zone_hint: str | None = zone_in_parens.group(1) if zone_in_parens else None
+    fragment_clean = re.sub(r"\([^)]*\)", "", fragment).strip()
+
+    # Duration: look for range like "15-20s" or "10-15m" or plain "15s"
+    dur_range_pat = re.compile(
+        r"(\d+(?:\.\d+)?)\s*-\s*(\d+(?:\.\d+)?)\s*(s|sec|secs|seconds?|m(?!i)|min|mins|minutes?|h|hrs?|hours?|:\d\d)",
+        re.IGNORECASE,
+    )
+    dur_plain_pat = re.compile(
+        r"(\d+(?:\.\d+)?)\s*(s|sec|secs|seconds?|m(?!i)|min|mins|minutes?|h|hrs?|hours?)",
+        re.IGNORECASE,
+    )
+    colon_pat = re.compile(r"(\d+):(\d{2})")
+
+    duration_seconds: int | None = None
+    consumed_span: tuple[int, int] | None = None
+
+    m_range = dur_range_pat.search(fragment_clean)
+    m_plain = dur_plain_pat.search(fragment_clean)
+    m_colon = colon_pat.search(fragment_clean)
+
+    # Prefer the earliest-starting match so that an explicit "30mins" or "600m"
+    # at position 0 is not shadowed by a pace annotation like "8:40" or a range
+    # like "40-9:00" found later in the same fragment.
+    if m_range and m_plain and m_plain.start() <= m_range.start():
+        m_range = None
+    if m_range and m_colon and m_colon.start() <= m_range.start():
+        m_range = None
+    if m_colon and m_plain and m_plain.start() < m_colon.start():
+        m_colon = None
+
+    if m_range:
+        low = float(m_range.group(1))
+        high = float(m_range.group(2))
+        mid = _resolve_range(low, high, "midpoint")
+        unit = m_range.group(3).lower()
+        if unit.startswith("h"):
+            duration_seconds = int(mid * 3600)
+        elif unit.startswith(":"):
+            duration_seconds = int(mid * 60)
+        elif unit.startswith("m"):
+            # "m", "min", "mins", "minutes" all mean minutes; "miles" excluded by regex.
+            if _is_meters_not_minutes(low) or _is_meters_not_minutes(high):
+                raise WorkoutTranslationError(
+                    f"Distance-based range: {int(low)}-{int(high)}m detected."
+                )
+            duration_seconds = int(mid * 60)
+        else:
+            duration_seconds = int(mid)
+        consumed_span = (m_range.start(), m_range.end())
+    elif m_colon:
+        duration_seconds = int(m_colon.group(1)) * 60 + int(m_colon.group(2))
+        consumed_span = (m_colon.start(), m_colon.end())
+    elif m_plain:
+        val = float(m_plain.group(1))
+        unit = m_plain.group(2).lower()
+        if unit.startswith("h"):
+            duration_seconds = int(val * 3600)
+        elif unit.startswith("m"):
+            # "m", "min", "mins", "minutes" all mean minutes; "miles" excluded by regex.
+            if _is_meters_not_minutes(val):
+                raise WorkoutTranslationError(
+                    f"Distance-based step: {int(val)}m detected."
+                )
+            duration_seconds = int(val * 60)
+        else:
+            duration_seconds = int(val)
+        consumed_span = (m_plain.start(), m_plain.end())
+
+    # Intensity: everything that's not the duration and not digits/punctuation
+    if consumed_span is not None:
+        intensity_text = (
+            fragment_clean[: consumed_span[0]] + " " + fragment_clean[consumed_span[1] :]
+        ).strip()
+    else:
+        intensity_text = fragment_clean
+
+    # Prefer explicit zone hint from parens
+    if zone_hint:
+        intensity = _map_intensity(zone_hint, sport_type)
+    else:
+        # Try to find an intensity keyword in the remaining text
+        intensity = _identify_intensity(intensity_text, sport_type)
+
+    return duration_seconds, intensity
+
+
+def _identify_intensity(text: str, sport_type: str) -> str:
+    """Scan text for known intensity keywords, longest match first."""
+    lower = text.lower().strip()
+    # Handle X->Y range notation (e.g. @MP->HMP, z3->z4): take the target (right side).
+    arrow_m = re.search(r"(\w+)\s*->\s*(\w+)", lower)
+    if arrow_m:
+        target = arrow_m.group(2).strip()
+        if target in INTENSITY_MAP:
+            return INTENSITY_MAP[target]
+        zm = re.fullmatch(r"z(\d)(?:-z\d)?", target)
+        if zm:
+            return f"z{zm.group(1)} pace"
+    # Check multi-word keys first (longest first)
+    for key in sorted(INTENSITY_MAP.keys(), key=len, reverse=True):
+        if key in lower:
+            return INTENSITY_MAP[key]
+    # Zone pattern Z1-Z5
+    zm = re.search(r"\bz(\d)(?:-z\d)?\b", lower, re.IGNORECASE)
+    if zm:
+        return f"z{zm.group(1)} pace"
+    return "z2 pace"
+
+
+# ---------------------------------------------------------------------------
+# Inline repeat pattern: "N x work [and|with|/] recovery" (no parentheses)
+# ---------------------------------------------------------------------------
+
+
+def _extract_inline_repeat_block(
+    description: str,
+) -> tuple[int, str, str, str] | None:
+    """
+    Find the "N x work [and|with|/] recovery" prose pattern (no parentheses).
+
+    Handles:
+    - ``8 x 4:00mins @MP->HMP and 2:00mins easy``
+    - ``- 8 x 4:00mins @MP->HMP and 2:00mins easy``  (bullet prefix)
+    - ``4 x 15mins at MP with 5 mins rest``
+    - ``6-8 x 800s with 400m jog rest``
+
+    Returns ``(reps, before_text, work_text, recovery_text)`` or ``None``.
+    """
+    # Strip a leading bullet/dash prefix (e.g. "- 8 x …")
+    desc = re.sub(r"^\s*[-*•]\s+", "", description.strip())
+
+    # Match "N x" or "N-Mx" where x is NOT immediately followed by "("
+    # (paren form is handled by _extract_repeat_block).
+    # Require \b before N to avoid matching e.g. "Z5x".
+    pattern = re.compile(
+        r"\b(\d+)(?:-(\d+))?\s*[xX](?!\s*\()\s+",
+        re.IGNORECASE,
+    )
+    m = pattern.search(desc)
+    if not m:
+        return None
+
+    low = float(m.group(1))
+    high = float(m.group(2)) if m.group(2) else low
+    reps = max(1, int(_resolve_range(low, high, "midpoint_rounded_down")))
+
+    before_text = desc[: m.start()].strip()
+    rest = desc[m.end() :].strip()
+
+    # Split on a recovery separator followed by a digit ("and 2:00", "with 5 mins")
+    sep_m = re.search(r"\s+(?:and|with)\s+(?=\d)", rest, re.IGNORECASE)
+    slash_m = re.search(r"\s*/\s*", rest)
+
+    if sep_m:
+        work_text = rest[: sep_m.start()].strip()
+        recovery_text = rest[sep_m.end() :].strip()
+    elif slash_m:
+        work_text = rest[: slash_m.start()].strip()
+        recovery_text = rest[slash_m.end() :].strip()
+    else:
+        work_text = rest
+        recovery_text = ""
+
+    return reps, before_text, work_text, recovery_text
+
+
+def _build_inline_repeat(
+    inline: tuple[int, str, str, str],
+    duration_seconds: int,
+    sport_type: str,
+) -> str:
+    """Build Intervals.icu format from an inline ``N x work [sep] recovery`` block."""
+    reps, before_text, work_text, recovery_text = inline
+
+    # Parse work step
+    work_dur, work_intensity = _parse_step_fragment(work_text, sport_type)
+    if work_dur is None:
+        raise WorkoutTranslationError(
+            f"Could not parse work duration from: {work_text!r}"
+        )
+
+    # Parse recovery step (duration may be absent for distance-based recoveries)
+    rec_dur: int | None = None
+    rec_intensity = "z2 pace"
+    if recovery_text:
+        rec_dur, rec_intensity = _parse_step_fragment(recovery_text, sport_type)
+
+    # Sanity check: work × reps must fit within total duration
+    if work_dur * reps > duration_seconds:
+        raise WorkoutTranslationError(
+            f"Work {work_dur}s × {reps} reps = {work_dur * reps}s exceeds "
+            f"total {duration_seconds}s. Likely distance-based intervals."
+        )
+
+    # Time already accounted for
+    work_total = work_dur * reps
+    rec_total = (rec_dur or 0) * reps
+    interval_total = work_total + rec_total
+
+    # Parse any explicit warmup text before the "N x"
+    before_steps = _parse_surrounding(before_text, sport_type) if before_text else []
+    known_before = sum(d for d, _ in before_steps)
+
+    remaining = duration_seconds - known_before - interval_total
+
+    # If recovery duration could not be parsed but there is recovery text,
+    # distribute the remaining time evenly across reps as recovery.
+    if rec_dur is None and recovery_text and remaining > 0 and reps > 0:
+        rec_dur = remaining // reps
+        rec_intensity = _identify_intensity(recovery_text, sport_type)
+        remaining = duration_seconds - known_before - work_total - rec_dur * reps
+
+    lines: list[str] = []
+
+    # Warmup / base run
+    if before_steps:
+        for d, i in before_steps:
+            lines.append(f"- {_seconds_to_icu(d)} {i}")
+    elif remaining > 60:
+        base_intensity = (
+            _identify_intensity(before_text, sport_type) if before_text else "z2 pace"
+        )
+        lines.append(f"- {_seconds_to_icu(remaining)} {base_intensity}")
+
+    # Blank line before interval block
+    if lines:
+        lines.append("")
+
+    lines.append(f"{reps}x")
+    lines.append(f"- {_seconds_to_icu(work_dur)} {work_intensity}")
+    if rec_dur is not None and rec_dur > 0:
+        lines.append(f"- {_seconds_to_icu(rec_dur)} {rec_intensity}")
+
+    return "\n".join(lines).strip()
+
+
+# ---------------------------------------------------------------------------
+# Commentary-bullet detection (Phase 5a — P2)
+# ---------------------------------------------------------------------------
+
+# Bullet lines that start with these words are coaching cues, not steps.
+_COMMENTARY_RE = re.compile(
+    r"^(by\s|total\s|aim\s|note[:\s]|start\s|priority\s|if\s|goal[:\s]|"
+    r"cool\s+down\s+to|hitting\s|practice\s|only\s+do\s)",
+    re.IGNORECASE,
+)
+# Lines that contain an arithmetic summary like "20 easy + 48 w/o" are also commentary.
+_ARITHMETIC_RE = re.compile(r"\d+\s*\w+\s*\+\s*\d+")
+
+
+def _is_commentary_bullet(content: str) -> bool:
+    """Return True if a bullet/line content is a coaching cue rather than a workout step."""
+    if _COMMENTARY_RE.match(content):
+        return True
+    if _ARITHMETIC_RE.search(content):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Multi-line bullet-list parser
+# ---------------------------------------------------------------------------
+
+
+def _parse_bullet_list(description: str, sport_type: str) -> str | None:
+    """
+    Parse a description that consists of ≥2 bullet lines into structured steps.
+
+    Each bullet is treated as an independent workout segment.  A bullet that
+    contains an inline "N x work [sep] recovery" pattern is emitted as a repeat
+    block (with surrounding blank lines); all other bullets become plain steps.
+
+    Returns the formatted ICU string, or ``None`` if there are fewer than 2
+    bullet lines in the description.
+    """
+    lines = description.strip().splitlines()
+    bullet_lines = [l.strip() for l in lines if re.match(r"^-\s", l.strip())]
+
+    if len(bullet_lines) < 2:
+        return None
+
+    # Each block is ("step", [line, ...]) or ("repeat", [line, ...])
+    blocks: list[tuple[str, list[str]]] = []
+
+    for bullet in bullet_lines:
+        content = bullet[2:].strip()  # strip leading "- "
+
+        # Skip coaching-cue bullets (commentary bleed — Phase 5a P2)
+        if _is_commentary_bullet(content):
+            continue
+
+        # Check for an inline Nx pattern embedded in this bullet
+        inline = _extract_inline_repeat_block(content)
+        if inline is not None:
+            reps, _before, work_text, recovery_text = inline
+            work_dur, work_intensity = _parse_step_fragment(work_text, sport_type)
+            if work_dur is not None and work_dur > 0:
+                repeat_lines: list[str] = [
+                    f"{reps}x",
+                    f"- {_seconds_to_icu(work_dur)} {work_intensity}",
+                ]
+                if recovery_text:
+                    rec_dur, rec_intensity = _parse_step_fragment(recovery_text, sport_type)
+                    if rec_dur is not None and rec_dur > 0:
+                        repeat_lines.append(f"- {_seconds_to_icu(rec_dur)} {rec_intensity}")
+                blocks.append(("repeat", repeat_lines))
+                continue
+
+        # Plain step
+        dur, intensity = _parse_step_fragment(content, sport_type)
+        if dur is not None and dur > 0:
+            blocks.append(("step", [f"- {_seconds_to_icu(dur)} {intensity}"]))
+
+    if not blocks:
+        return None
+
+    # Assemble: insert blank lines before and after every repeat block
+    result: list[str] = []
+    for i, (block_type, block_lines) in enumerate(blocks):
+        prev_type = blocks[i - 1][0] if i > 0 else None
+        if i > 0 and (block_type == "repeat" or prev_type == "repeat"):
+            result.append("")
+        result.extend(block_lines)
+
+    return "\n".join(result)
+
+
+# ---------------------------------------------------------------------------
+# Non-bullet multi-segment parser (Phase 5a — P3)
+# ---------------------------------------------------------------------------
+
+
+def _parse_plain_segments(description: str, sport_type: str) -> str | None:
+    """
+    Parse a description made of newline-separated plain lines (no "- " prefix).
+
+    Each non-empty, non-commentary line is attempted as a workout step via
+    ``_parse_step_fragment``.  Returns a formatted ICU string if ≥ 2 lines
+    yield a valid duration; returns ``None`` otherwise.
+
+    Inserted between ``_parse_bullet_list`` and ``_extract_inline_repeat_block``
+    in ``_translate()`` so that multi-segment prose descriptions like::
+
+        45 mins easy to moderate
+        30mins at goal marathon pace
+        15 mins cool down
+
+    are captured without requiring dash-prefixed bullets.
+    """
+    lines = description.strip().splitlines()
+    # Only process non-bullet, non-empty lines
+    candidate_lines = [
+        ln.strip()
+        for ln in lines
+        if ln.strip() and not re.match(r"^-\s", ln.strip())
+    ]
+
+    if len(candidate_lines) < 2:
+        return None
+
+    steps: list[tuple[int, str]] = []
+    for line in candidate_lines:
+        if _is_commentary_bullet(line):
+            continue
+        try:
+            dur, intensity = _parse_step_fragment(line, sport_type)
+        except WorkoutTranslationError:
+            continue
+        if dur is not None and dur > 0:
+            steps.append((dur, intensity))
+
+    if len(steps) < 2:
+        return None
+
+    return "\n".join(f"- {_seconds_to_icu(d)} {i}" for d, i in steps)
+
+
+# ---------------------------------------------------------------------------
+# High-level translation
+# ---------------------------------------------------------------------------
+
+
+def translate_workout(
+    description: str,
+    duration_seconds: int,
+    sport_type: str = "Run",
+) -> str:
+    """
+    Translate a FinalSurge descriptive workout into Intervals.icu plain-text format.
+
+    The pipeline runs in order:
+    1. Deterministic regex pipeline (Phases 1–5a).
+    2. Local LLM fallback via ollama (Phase 5b) — only when the regex pipeline
+       raises ``WorkoutTranslationError`` (e.g. distance-based intervals).
+    3. Simple single-step fallback — when the LLM is unavailable or also fails.
+
+    Args:
+        description: Natural language workout description from FinalSurge.
+        duration_seconds: Total workout duration in seconds.
+        sport_type: "Run", "Ride", or "Swim".
+
+    Returns:
+        Intervals.icu formatted workout string, or a simple fallback if all
+        translation attempts fail.
+    """
+    try:
+        return _translate(description, duration_seconds, sport_type)
+    except WorkoutTranslationError as exc:
+        logger.info("Regex pipeline could not translate workout (%s); trying LLM fallback.", exc)
+        try:
+            from .workout_translator_llm import _llm_available, _translate_with_llm
+
+            if _llm_available():
+                result = _translate_with_llm(description, duration_seconds, sport_type)
+                logger.info("LLM fallback succeeded.")
+                return result
+            logger.warning("LLM unavailable (ollama not running or model not pulled).")
+        except Exception as llm_exc:  # noqa: BLE001
+            logger.warning("LLM fallback failed: %s", llm_exc)
+        logger.warning("Using simple fallback for: %s", description[:80])
+        return _build_simple(description, duration_seconds, sport_type)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Unexpected translation error: %s. Returning original.", exc)
+        return description
+
+
+def _translate(description: str, duration_seconds: int, sport_type: str) -> str:
+    result = _extract_repeat_block(description)
+
+    if result is None:
+        # Strides / pickups keyword → apply standard 5 × (15 s z5 / 1m45s z1) template.
+        # Only fires when there is no explicit zone annotation already in the description
+        # (those are handled correctly by the paren-form or inline parsers above/below).
+        if (
+            sport_type == "Run"
+            and _STRIDES_RE.search(description)
+            and not _EXPLICIT_ZONE_RE.search(description)
+        ):
+            return _build_strides(duration_seconds)
+
+        # Try multi-line bullet-list first (handles pure step lists and bullets
+        # that embed an Nx pattern, without being confused by surrounding prose).
+        bullet_result = _parse_bullet_list(description, sport_type)
+        if bullet_result is not None:
+            return bullet_result
+
+        # Phase 5a P3: non-bullet multi-segment plain descriptions
+        # (e.g. "45 mins easy\n30mins at MP\n15 mins cool down")
+        plain_result = _parse_plain_segments(description, sport_type)
+        if plain_result is not None:
+            return plain_result
+
+        # Try the prose/bullet "N x work [sep] recovery" pattern
+        inline = _extract_inline_repeat_block(description)
+        if inline is not None:
+            return _build_inline_repeat(inline, duration_seconds, sport_type)
+        # No repeat block – simple workout
+        return _build_simple(description, duration_seconds, sport_type)
+
+    reps, inner, surrounding = result
+    before_text, after_text = surrounding[0], surrounding[1]
+
+    # Parse the interval steps
+    interval_steps = _parse_inner_steps(inner, sport_type)
+    if not interval_steps:
+        raise WorkoutTranslationError("Could not parse any steps from repeat block.")
+
+    # Separate work steps from recovery steps heuristically:
+    # The last step in the inner block is usually the recovery.
+    # If only one step, infer recovery from "full recovery" text or use 5× work duration.
+    if len(interval_steps) == 1:
+        work_steps = interval_steps
+        # Check if description mentions recovery (no explicit duration given)
+        recovery_keyword = re.search(r"\bfull\s+recovery\b|\brecovery\b|\bjog\b", inner, re.IGNORECASE)
+        if recovery_keyword:
+            inferred_recovery_dur = max(60, interval_steps[0][0] * 5)
+            recovery_intensity = _identify_intensity(
+                inner[recovery_keyword.start() :], sport_type
+            )
+            recovery_steps: list[tuple[int, str]] = [(inferred_recovery_dur, recovery_intensity)]
+        else:
+            recovery_steps = []
+    else:
+        work_steps = interval_steps[:-1]
+        recovery_steps = [interval_steps[-1]]
+
+    # Total time consumed by intervals
+    interval_work_secs = sum(d for d, _ in work_steps) * reps
+    interval_recovery_secs = sum(d for d, _ in recovery_steps) * reps
+    total_interval_secs = interval_work_secs + interval_recovery_secs
+
+    # Parse surrounding segments for base run / cooldown
+    before_steps = _parse_surrounding(before_text, sport_type)
+    after_steps = _parse_surrounding(after_text, sport_type)
+
+    # Known surrounding time
+    known_before_secs = sum(d for d, _ in before_steps)
+    known_after_secs = sum(d for d, _ in after_steps)
+
+    # Remaining time → assign to base run if before_text has no explicit duration
+    remaining_secs = duration_seconds - total_interval_secs - known_before_secs - known_after_secs
+
+    lines: list[str] = []
+
+    # Build base run from before_steps or remaining time
+    if before_steps:
+        for dur, intensity in before_steps:
+            lines.append(f"- {_seconds_to_icu(dur)} {intensity}")
+    elif remaining_secs > 0 and not after_steps:
+        # All remaining time before intervals
+        base_intensity = _identify_intensity(before_text, sport_type)
+        lines.append(f"- {_seconds_to_icu(remaining_secs)} {base_intensity}")
+    elif remaining_secs > 0:
+        # Split remaining: half before, half after as cooldown
+        half = remaining_secs // 2
+        base_intensity = _identify_intensity(before_text, sport_type)
+        if half > 0:
+            lines.append(f"- {_seconds_to_icu(half)} {base_intensity}")
+
+    # Interval block (blank line before)
+    if lines:
+        lines.append("")
+    lines.append(f"{reps}x")
+    for dur, intensity in work_steps:
+        lines.append(f"- {_seconds_to_icu(dur)} {intensity}")
+    for dur, intensity in recovery_steps:
+        lines.append(f"- {_seconds_to_icu(dur)} {intensity}")
+
+    # After steps (cooldown)
+    if after_steps:
+        lines.append("")
+        for dur, intensity in after_steps:
+            lines.append(f"- {_seconds_to_icu(dur)} {intensity}")
+    elif remaining_secs > 0 and known_before_secs == 0 and not before_steps:
+        # Already handled above (no explicit after either)
+        pass
+    elif remaining_secs > 0:
+        # Put remaining as cooldown
+        half = remaining_secs - (remaining_secs // 2)
+        cool_intensity = _identify_intensity(after_text, sport_type) if after_text.strip() else "z2 pace"
+        if half > 0:
+            lines.append("")
+            lines.append(f"- {_seconds_to_icu(half)} {cool_intensity}")
+
+    return "\n".join(lines).strip()
+
+
+def _parse_surrounding(text: str, sport_type: str) -> list[tuple[int, str]]:
+    """
+    Parse text outside a repeat block into a list of (duration_seconds, intensity) steps.
+
+    Splits on sentence boundaries / multiple durations if present.
+    """
+    text = text.strip()
+    if not text:
+        return []
+
+    steps: list[tuple[int, str]] = []
+
+    # Look for explicit "MM:SS" or "Xm" tokens followed by intensity
+    segment_pat = re.compile(
+        r"(\d+:\d{2}|\d+(?:\.\d+)?\s*(?:min|mins|minutes?|s|sec|secs|h|hrs?)\b)",
+        re.IGNORECASE,
+    )
+    segments = list(segment_pat.finditer(text))
+
+    if not segments:
+        return []
+
+    for i, seg in enumerate(segments):
+        dur = _parse_duration_to_seconds(seg.group(0))
+        if dur is None:
+            continue
+        # Intensity: text between this segment and the next (or end)
+        start = seg.end()
+        end = segments[i + 1].start() if i + 1 < len(segments) else len(text)
+        intensity_text = text[start:end]
+        intensity = _identify_intensity(intensity_text, sport_type)
+        steps.append((dur, intensity))
+
+    return steps
+
+
+def _build_simple(description: str, duration_seconds: int, sport_type: str) -> str:
+    """Build a single-step workout when there's no repeat block."""
+    intensity = _identify_intensity(description, sport_type)
+    return f"- {_seconds_to_icu(duration_seconds)} {intensity}"

--- a/src/intervals_icu_mcp/workout_translator_llm.py
+++ b/src/intervals_icu_mcp/workout_translator_llm.py
@@ -1,0 +1,237 @@
+"""Local LLM fallback for workout translation (Phase 5b).
+
+Uses ollama as the default runtime — no GPU required, runs a background
+``ollama serve`` process.  Falls back gracefully when unavailable.
+
+Recommended setup
+-----------------
+1. Install ollama: https://ollama.com/download
+2. Pull a model::
+
+       ollama pull phi3:mini          # ~2.2 GB — best size/quality
+       # or: ollama pull llama3.2:3b  # ~2.0 GB — strong instruction following
+       # or: ollama pull mistral:7b-instruct  # ~4.1 GB — most robust
+
+3. Ollama starts automatically on first use (or run ``ollama serve`` manually).
+
+The LLM is only invoked when the deterministic regex pipeline raises
+``WorkoutTranslationError`` (e.g. distance-based intervals with no parseable
+minute duration).  Most workouts are handled without it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_OLLAMA_BASE_URL = "http://localhost:11434"
+# Preferred model — override by setting INTERVALS_ICU_LLM_MODEL env var.
+_DEFAULT_MODEL = "phi3:mini"
+_AVAILABILITY_TIMEOUT = 1   # seconds for the ping (keep short — checked per-workout)
+_GENERATION_TIMEOUT = 60    # seconds for a full generation
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+
+def _llm_available(model: str = _DEFAULT_MODEL) -> bool:
+    """Return True if ollama is running and *model* is available locally."""
+    try:
+        with urllib.request.urlopen(
+            f"{_OLLAMA_BASE_URL}/api/tags", timeout=_AVAILABILITY_TIMEOUT
+        ) as resp:
+            data = json.loads(resp.read().decode())
+            available_models: list[str] = [m["name"] for m in data.get("models", [])]
+            # Accept both "phi3:mini" and "phi3:mini-4k" style names
+            base = model.split(":")[0]
+            return any(m.startswith(base) for m in available_models)
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = """\
+You are a workout translator. Convert FinalSurge workout descriptions to \
+Intervals.icu plain-text format.
+
+Format rules:
+- Steps start with "- " (dash space)
+- Duration: 30m, 15s, 1h, 1m30s  (m = minutes, s = seconds — NOT meters/miles)
+- Intensity: z1–z5 pace  (z1=recovery, z2=easy, z3=tempo/MP, z4=threshold/HMP, z5=hard/strides/on)
+- Repeat blocks: a standalone "Nx" line followed by the steps; blank lines before and after the block
+- Always replace N with the actual integer rep count from the description (e.g. "8 x" → 8x, "6-8x" → 7x)
+- No nested repeats — flatten all intervals to one level
+- Distance-based intervals (200m, 800m, 1600m etc.): estimate each step duration \
+from total workout time divided by (reps × 2) for work, remainder for recovery
+- "on"/"off" → z5/z1 pace respectively
+- Use the exact durations written in the description. Do not calculate, scale, or \
+proportionally adjust durations that are already specified in minutes or seconds.
+
+Output constraints — your entire response must consist ONLY of lines matching one of:
+  • "- <duration> <intensity>" (a workout step)
+  • "<integer>x" (a repeat count, e.g. 8x)
+  • a blank line (used as separator around repeat blocks)
+Do not output prose, alternatives, descriptions, markdown, code fences, bullet \
+symbols other than "- ", or any other text whatsoever.
+Do not use markdown. Do not use backtick code fences. Do not use any formatting \
+markup. Raw text only."""
+
+# Few-shot examples as (user_turn, assistant_turn) pairs.
+# Using chat turns means the model sees these as completed exchanges, not a
+# pattern to "continue" — which prevents it from generating "Example N+1" hallucinations.
+# Rep counts are non-trivial integers (7x, 8x, 10x) to reinforce "replace N with actual count".
+_FEW_SHOT: list[tuple[str, str]] = [
+    (
+        "Duration: 45m\nDescription: Easy running throughout 6-8x( 15-20s @ Stride / Fast (Z5) Full recovery easy jog )",
+        "- 18m z2 pace\n\n7x\n- 17s z5 pace\n- 1m45s z2 pace",
+    ),
+    (
+        "Duration: 1h20m\nDescription: 8 x 4:00mins @MP->HMP and 2:00mins easy",
+        "- 32m z2 pace\n\n8x\n- 4m z4 pace\n- 2m z2 pace",
+    ),
+    (
+        "Duration: 1h\nDescription: 8 x 600m@Tempo (200m jog rest)",
+        "- 16m z2 pace\n\n8x\n- 3m z3 pace\n- 1m30s z1 pace",
+    ),
+    (
+        "Duration: 50m\nDescription: 10 x 400m @ 5K effort (90s recovery jog)",
+        "- 12m z2 pace\n\n10x\n- 1m30s z5 pace\n- 1m30s z1 pace",
+    ),
+    (
+        "Duration: 1h30m\nDescription: 45 mins easy to moderate\n30mins at goal marathon pace: 8:40-9:00\n15 mins cool down\n\nIf feeling tired, shorten even more!",
+        "- 45m z2 pace\n- 30m z3 pace\n- 15m z2 pace",
+    ),
+]
+
+
+def _build_messages(description: str, duration_seconds: int) -> list[dict[str, str]]:
+    """Build the /api/chat messages list with system prompt, few-shot pairs, and live query."""
+    from .workout_translator import _seconds_to_icu
+
+    messages: list[dict[str, str]] = [{"role": "system", "content": _SYSTEM_PROMPT}]
+    for user_turn, assistant_turn in _FEW_SHOT:
+        messages.append({"role": "user", "content": user_turn})
+        messages.append({"role": "assistant", "content": assistant_turn})
+    total_dur = _seconds_to_icu(duration_seconds)
+    messages.append({"role": "user", "content": f"Duration: {total_dur}\nDescription: {description}"})
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Warmup
+# ---------------------------------------------------------------------------
+
+_warmed_up: bool = False
+
+
+def _warmup_llm(model: str = _DEFAULT_MODEL) -> None:
+    """Send a trivial request to eliminate cold-start latency on first real use.
+
+    Sets the module-level ``_warmed_up`` flag on success so this is only done once
+    per process.  Silently ignores any errors — warmup is best-effort.
+    """
+    import os
+
+    global _warmed_up
+    if _warmed_up:
+        return
+    resolved_model = os.environ.get("INTERVALS_ICU_LLM_MODEL", model)
+    payload = {
+        "model": resolved_model,
+        "messages": [
+            {"role": "system", "content": "Reply OK."},
+            {"role": "user", "content": "ping"},
+        ],
+        "stream": False,
+        "options": {"temperature": 0.0, "num_predict": 5},
+    }
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"{_OLLAMA_BASE_URL}/api/chat",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as _:
+            pass
+        _warmed_up = True
+        logger.debug("LLM warmup complete (model=%s).", resolved_model)
+    except Exception as exc:
+        logger.debug("LLM warmup failed (ignored): %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Translation
+# ---------------------------------------------------------------------------
+
+
+def _translate_with_llm(
+    description: str,
+    duration_seconds: int,
+    sport_type: str = "Run",
+    model: str = _DEFAULT_MODEL,
+) -> str:
+    """Translate a workout description using a local LLM via ollama.
+
+    Args:
+        description: Natural language workout description.
+        duration_seconds: Total workout duration in seconds.
+        sport_type: Sport type hint (passed in prompt context for future use).
+        model: Ollama model name (default: ``phi3:mini``).
+
+    Returns:
+        Intervals.icu formatted workout string.
+
+    Raises:
+        RuntimeError: If ollama is unavailable or returns an error.
+    """
+    import os
+
+    resolved_model = os.environ.get("INTERVALS_ICU_LLM_MODEL", model)
+    _warmup_llm(model)
+    messages = _build_messages(description, duration_seconds)
+
+    payload = {
+        "model": resolved_model,
+        "messages": messages,
+        "stream": False,
+        "options": {
+            "temperature": 0.1,   # Low temp for deterministic structured output
+            "num_predict": 300,   # Workouts are short; cap token spend
+        },
+    }
+
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"{_OLLAMA_BASE_URL}/api/chat",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=_GENERATION_TIMEOUT) as resp:
+            result = json.loads(resp.read().decode())
+            response_text = result.get("message", {}).get("content", "").strip()
+            if not response_text:
+                raise RuntimeError("LLM returned an empty response.")
+            logger.info("LLM translation succeeded (model=%s).", resolved_model)
+            return response_text
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Cannot reach ollama at {_OLLAMA_BASE_URL}: {exc}") from exc
+    except Exception as exc:
+        raise RuntimeError(f"LLM generation failed: {exc}") from exc

--- a/tests/benchmark_phase5c.py
+++ b/tests/benchmark_phase5c.py
@@ -1,0 +1,392 @@
+"""Phase 5c benchmark: regex+LLM hybrid vs. straight-to-LLM.
+
+Runs the 10 benchmark workouts from the design doc against both pipelines,
+measures wall-clock time, and prints a scored comparison table for manual review.
+
+Usage:
+    uv run python tests/benchmark_phase5c.py
+    uv run python tests/benchmark_phase5c.py --llm-only   # skip regex
+    uv run python tests/benchmark_phase5c.py --model mistral:7b-instruct
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import textwrap
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Ensure src/ is importable when run from repo root
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from intervals_icu_mcp.workout_translator import _build_simple, translate_workout
+from intervals_icu_mcp.workout_translator_llm import (
+    _DEFAULT_MODEL,
+    _llm_available,
+    _translate_with_llm,
+)
+
+# ---------------------------------------------------------------------------
+# Benchmark corpus
+# ---------------------------------------------------------------------------
+# 10 workouts immediately preceding the 2026-02-01 half marathon.
+# pre_phase5: output from the post-Phase-4 translator (before this PR).
+# key_fix:    which Phase-5a bug this case exercises.
+
+@dataclass
+class Case:
+    date: str
+    name: str
+    description: str
+    duration_seconds: int
+    key_fix: str
+    pre_phase5: str        # known (broken) output before Phase 5
+    expected: str = ""     # ideal expected output (where deterministic)
+    notes: str = ""
+
+CASES: list[Case] = [
+    Case(
+        date="2026-01-06",
+        name="Easy Run w/Strides (40 min)",
+        description="4 x 100m strides with full rest (or 15-20s pickups)",
+        duration_seconds=2400,
+        key_fix="strides template (already passing)",
+        pre_phase5="- 30m z2 pace\n\n5x\n- 15s z5 pace\n- 1m45s z1 pace",
+        expected="- 30m z2 pace\n\n5x\n- 15s z5 pace\n- 1m45s z1 pace",
+        notes="Pre-existing pass; strides template should still fire",
+    ),
+    Case(
+        date="2026-01-08",
+        name="Tempo + Pickups (80 min)",
+        description=(
+            "- 3-5 miles@HMP\n"
+            "- take full rest\n"
+            "- 4-6 x 30s on / 2 mins off"
+        ),
+        duration_seconds=4800,
+        key_fix="P4 on/off + P1 miles (no unit match)",
+        pre_phase5="5x\n- 30s z2 pace\n- 2m z2 pace",
+        expected="5x\n- 30s z5 pace\n- 2m z1 pace",
+        notes="P4: on->z5, off->z1. miles not parsed (m(?!i)), so HMP bullet dropped.",
+    ),
+    Case(
+        date="2026-01-10",
+        name="Long Run with Pickups (140 min)",
+        description=(
+            "10-12 x 30s on and 2 mins off easy jog\n\n"
+            "- 30 mins easy \n"
+            "- 60 mins easy-> moderate\n"
+            "- 30 mins of workout (30s on / 2 off)\n"
+            "- 10-20mins easy cool down"
+        ),
+        duration_seconds=8400,
+        key_fix="P4 on/off (header line not parsed -- partial)",
+        pre_phase5=(
+            "- 30m z2 pace\n"
+            "- 1h z2 pace\n"
+            "- 30m z2 pace\n"
+            "- 15m z2 pace"
+        ),
+        expected=(
+            "- 30m z2 pace\n"
+            "- 1h z2 pace\n"
+            "- 30m z2 pace\n"
+            "- 15m z2 pace"
+        ),
+        notes=(
+            "Bullet structure preserved; header 'on/off' pattern is not parsed "
+            "(the regex pipeline skips non-bullet header lines). LLM should handle this better."
+        ),
+    ),
+    Case(
+        date="2026-01-13",
+        name="600s (70 min)",
+        description=(
+            "- 8 x 600m@Tempo 8:20-30ish pace or 3:07-10 (200m jog rest)\n"
+            "- If you don't have access to a track, swap to 3 mins on / 1 off\n\n"
+            "Priority is the weekend workout, so listen to your body and don't be afraid "
+            "to shorten the workout or go slower if needed."
+        ),
+        duration_seconds=4200,
+        key_fix="P1 meters (600m) + P2 commentary",
+        pre_phase5="8x\n- 8m20s z3 pace\n\n- 3m z2 pace",
+        expected="8x\n- 3m z3 pace\n- 1m z1 pace",
+        notes=(
+            "P1: 600m triggers WorkoutTranslationError -> LLM or simple fallback. "
+            "P2 would have filtered 'If...' bullet but P1 fires first."
+        ),
+    ),
+    Case(
+        date="2026-01-14",
+        name="Easy Run w/4-6 strides (30 min) --no description",
+        description="",
+        duration_seconds=1800,
+        key_fix="no description (fallback --no fix needed)",
+        pre_phase5="- 30m z2 pace",
+        expected="- 30m z2 pace",
+        notes="Empty description; simple fallback. P5 design notes this as P5 (name-based strides).",
+    ),
+    Case(
+        date="2026-01-16",
+        name="Easy Run w/Strides (40 min)",
+        description="4 x 100m strides with full rest (or 15-20s pickups)",
+        duration_seconds=2400,
+        key_fix="strides template (already passing)",
+        pre_phase5="- 30m z2 pace\n\n5x\n- 15s z5 pace\n- 1m45s z1 pace",
+        expected="- 30m z2 pace\n\n5x\n- 15s z5 pace\n- 1m45s z1 pace",
+        notes="Identical to 2026-01-06.",
+    ),
+    Case(
+        date="2026-01-17",
+        name="Last Big Workout! (150 min)",
+        description=(
+            "Total Time: 2:30-2:45\n"
+            "- Hitting total time is first priority, but only do 2:45 if you are feeling good\n"
+            "- Practice this like race day, and start slower than you think you need to :)\n\n"
+            "Workout:\n"
+            "- 45 mins easy\n"
+            "- 2 x 40mins@MP(8:40-55) with 10 mins easy rest in between\n"
+            "- 15-30 mins easy"
+        ),
+        duration_seconds=9000,
+        key_fix="P2 commentary-bullet bleed",
+        pre_phase5="- 2m45s z2 pace\n- 45m z2 pace\n\n2x\n- 40m z3 pace\n- 10m z1 pace\n\n- 22m30s z2 pace",
+        expected="- 45m z2 pace\n\n2x\n- 40m z3 pace\n- 10m z1 pace\n\n- 22m30s z2 pace",
+        notes="P2 drops 'Hitting...' and 'Practice...' bullets. '2:45' spurious step removed.",
+    ),
+    Case(
+        date="2026-01-20",
+        name="Cutdown (60 min)",
+        description=(
+            "4400k Cutdown - 2mins rest all\n"
+            "- 1600m@Tempo->10k (8:30? who knows after the last big workout lol)\n"
+            "- 1200m@10k ~5:40-50 or 1:53ish per 400m\n"
+            "- 800m@5k ~3:40-50 or 1:50ish per 400m\n"
+            "- 400m@3k ~1:40\n"
+            "- 2 x 200m@Mile, 48-52s"
+        ),
+        duration_seconds=3600,
+        key_fix="P1 meters (1600m, 1200m, 800m, 400m, 200m)",
+        pre_phase5="- 26h40m z3 pace\n- 5m40s z2 pace\n- 3m40s z2 pace\n- 1m40s z2 pace\n\n2x\n- 50s z2 pace",
+        expected="- 1h z3 pace",
+        notes=(
+            "P1: every bullet triggers WorkoutTranslationError -> LLM or simple fallback. "
+            "Simple fallback: total 60m at dominant intensity (tempo->z3). "
+            "LLM should produce structured rep-by-rep output."
+        ),
+    ),
+    Case(
+        date="2026-01-23",
+        name="Easy Run with Strides (25 min)",
+        description="Run 4-6 x 100m or 15-20s pickups, with full recovery",
+        duration_seconds=1500,
+        key_fix="strides template (already passing)",
+        pre_phase5="- 15m z2 pace\n\n5x\n- 15s z5 pace\n- 1m45s z1 pace",
+        expected="- 15m z2 pace\n\n5x\n- 15s z5 pace\n- 1m45s z1 pace",
+        notes="Strides template: 25 min - 10 min intervals = 15 min base run.",
+    ),
+    Case(
+        date="2026-01-24",
+        name="Last Workout! (90 min)",
+        description=(
+            "45 mins easy to moderate\n"
+            "30mins at goal marathon pace: 8:40-9:00\n"
+            "15 mins cool down\n\n"
+            "If feeling tired, shorten even more! Cutdown the 45mins to 30"
+        ),
+        duration_seconds=5400,
+        key_fix="P3 plain-segment descriptions",
+        pre_phase5="- 1h30m z3 pace",
+        expected="- 45m z2 pace\n- 30m z3 pace\n- 15m z2 pace",
+        notes=(
+            "P3: plain_segments parser fires on three duration lines. "
+            "'If feeling tired...' filtered by _is_commentary_bullet. "
+            "Pace annotation '8:40-9:00' doesn't affect '30mins' thanks to prefer-earliest fix."
+        ),
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+
+def _indent(text: str, prefix: str = "    ") -> str:
+    return textwrap.indent(text, prefix)
+
+def _score_label(output: str, expected: str, pre: str) -> str:
+    """Return a quick quality label comparing output to expected and pre-phase5."""
+    if not expected:
+        return "?"          # no ground truth defined
+    if output.strip() == expected.strip():
+        return "[PASS] 1.0"
+    # Partial credit: key lines correct
+    exp_lines = set(expected.strip().splitlines())
+    out_lines = set(output.strip().splitlines())
+    overlap = len(exp_lines & out_lines)
+    frac = overlap / max(len(exp_lines), 1)
+    if frac >= 0.75:
+        return f"[PART] 0.5  ({int(frac*100)}% lines match)"
+    # Better than pre-Phase 5?
+    if output.strip() != pre.strip():
+        return f"[FAIL] 0.0  (changed from pre; check manually)"
+    return "[FAIL] 0.0  (unchanged from pre-Phase-5)"
+
+# ---------------------------------------------------------------------------
+# Runners
+# ---------------------------------------------------------------------------
+
+def run_regex(case: Case) -> tuple[str, float]:
+    """Run translate_workout() and return (output, elapsed_seconds)."""
+    if not case.description:
+        return _build_simple(case.description or "easy", case.duration_seconds, "Run"), 0.0
+    t0 = time.perf_counter()
+    result = translate_workout(case.description, case.duration_seconds, "Run")
+    return result, time.perf_counter() - t0
+
+
+def run_llm(case: Case, model: str) -> tuple[str, float]:
+    """Run _translate_with_llm() directly and return (output, elapsed_seconds)."""
+    if not case.description:
+        return _build_simple(case.description or "easy", case.duration_seconds, "Run"), 0.0
+    t0 = time.perf_counter()
+    result = _translate_with_llm(case.description, case.duration_seconds, model=model)
+    return result, time.perf_counter() - t0
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+def print_report(
+    results_regex: list[tuple[str, float]],
+    results_llm: list[tuple[str, float]] | None,
+    model: str,
+) -> None:
+    hr = "-" * 80
+    print(f"\n{'=' * 80}")
+    print("  PHASE 5c BENCHMARK  --  regex+LLM hybrid  vs.  straight-to-LLM  ")
+    print(f"  LLM model: {model}   |   Cases: {len(CASES)}")
+    print(f"{'=' * 80}\n")
+
+    total_regex = 0.0
+    total_llm = 0.0
+    regex_scores: list[str] = []
+    llm_scores: list[str] = []
+
+    for i, case in enumerate(CASES):
+        regex_out, regex_t = results_regex[i]
+        print(f"{hr}")
+        print(f"  [{i+1:02d}] {case.date}  |  {case.name}")
+        print(f"       Key fix: {case.key_fix}")
+        if case.notes:
+            print(f"       Note:    {case.notes}")
+        print()
+
+        print(f"  PRE-PHASE-5 output:")
+        print(_indent(case.pre_phase5))
+        print()
+
+        rscore = _score_label(regex_out, case.expected, case.pre_phase5)
+        regex_scores.append(rscore)
+        total_regex += regex_t
+        print(f"  REGEX PIPELINE  [{regex_t*1000:.1f} ms]  score: {rscore}")
+        print(_indent(regex_out))
+
+        if results_llm is not None:
+            llm_out, llm_t = results_llm[i]
+            lscore = _score_label(llm_out, case.expected, case.pre_phase5)
+            llm_scores.append(lscore)
+            total_llm += llm_t
+            print()
+            print(f"  STRAIGHT-TO-LLM  [{llm_t:.2f} s]  score: {lscore}")
+            print(_indent(llm_out))
+
+        if case.expected:
+            print()
+            print(f"  EXPECTED:")
+            print(_indent(case.expected))
+
+        print()
+
+    print(f"{'=' * 80}")
+    print("  SUMMARY")
+    print(f"{'=' * 80}")
+    print(f"  Regex pipeline  -- total: {total_regex*1000:.1f} ms  "
+          f"({total_regex/len(CASES)*1000:.1f} ms/workout)")
+    if results_llm is not None:
+        print(f"  Straight-to-LLM -- total: {total_llm:.2f} s  "
+              f"({total_llm/len(CASES):.2f} s/workout)")
+        print()
+        week_regex  = total_regex  / len(CASES) * 10  # 10-workout week
+        week_llm    = total_llm    / len(CASES) * 10
+        print(f"  Projected 10-workout week sync time:")
+        print(f"    regex pipeline:  {week_regex*1000:.0f} ms")
+        print(f"    straight-to-LLM: {week_llm:.1f} s")
+    else:
+        print(f"  (LLM not available --run `ollama pull {model}` to enable LLM comparison)")
+
+    print()
+    print("  Per-case scores (regex):")
+    for i, (case, score) in enumerate(zip(CASES, regex_scores)):
+        print(f"    [{i+1:02d}] {case.date:12s}  {score}")
+    if results_llm is not None:
+        print()
+        print("  Per-case scores (straight-to-LLM):")
+        for i, (case, score) in enumerate(zip(CASES, llm_scores)):
+            print(f"    [{i+1:02d}] {case.date:12s}  {score}")
+
+    print(f"\n{'=' * 80}\n")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Phase 5c benchmark")
+    parser.add_argument("--llm-only", action="store_true", help="Skip regex pipeline")
+    parser.add_argument("--model", default=_DEFAULT_MODEL, help="Ollama model name")
+    parser.add_argument("--no-llm", action="store_true", help="Force skip LLM even if available")
+    args = parser.parse_args()
+
+    model = args.model
+    llm_ok = _llm_available(model) and not args.no_llm
+
+    print(f"\nRunning Phase 5c benchmark ({len(CASES)} workouts)")
+    print(f"LLM ({model}): {'available [ok]' if llm_ok else 'not available -- regex-only run'}")
+
+    # Regex pipeline
+    results_regex: list[tuple[str, float]] = []
+    if not args.llm_only:
+        print("\n>> Running regex+LLM hybrid pipeline...")
+        for case in CASES:
+            out, t = run_regex(case)
+            results_regex.append((out, t))
+            print(f"  {case.date} {case.name[:30]:<30}  {t*1000:6.1f} ms")
+    else:
+        results_regex = [("(skipped)", 0.0)] * len(CASES)
+
+    # LLM pipeline
+    results_llm: list[tuple[str, float]] | None = None
+    if llm_ok:
+        results_llm = []
+        print(f"\n>> Running straight-to-LLM pipeline (model={model})...")
+        for case in CASES:
+            if not case.description:
+                results_llm.append((_build_simple("easy", case.duration_seconds, "Run"), 0.0))
+                print(f"  {case.date} {case.name[:30]:<30}  (no-desc, skipped)")
+                continue
+            try:
+                out, t = run_llm(case, model)
+                results_llm.append((out, t))
+                print(f"  {case.date} {case.name[:30]:<30}  {t:.2f}s")
+            except Exception as exc:
+                results_llm.append((f"[LLM error: {exc}]", 0.0))
+                print(f"  {case.date} {case.name[:30]:<30}  ERROR: {exc}")
+
+    print_report(results_regex, results_llm, model)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_event_management.py
+++ b/tests/test_event_management.py
@@ -1,0 +1,466 @@
+"""Tests for event management tools — focusing on auto-translate integration."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import Response
+
+from intervals_icu_mcp.tools.event_management import (
+    _get_sport_type,
+    bulk_create_events,
+    create_event,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ATHLETE_ID = "i123456"
+EVENTS_URL = f"/athlete/{ATHLETE_ID}/events"
+BULK_EVENTS_URL = f"/athlete/{ATHLETE_ID}/events/bulk"
+
+
+def _make_event_response(
+    event_id: int = 1001,
+    name: str = "Test Workout",
+    category: str = "WORKOUT",
+    event_type: str = "Run",
+    description: str | None = None,
+    moving_time: int | None = None,
+) -> dict:
+    """Build a minimal Event API response dict."""
+    payload: dict = {
+        "id": event_id,
+        "start_date_local": "2026-04-10T00:00:00",
+        "name": name,
+        "category": category,
+        "type": event_type,
+    }
+    if description is not None:
+        payload["description"] = description
+    if moving_time is not None:
+        payload["moving_time"] = moving_time
+    return payload
+
+
+def _make_ctx(mock_config):
+    ctx = MagicMock()
+    ctx.get_state.return_value = mock_config
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Unit: _get_sport_type helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "event_type,expected",
+    [
+        ("Run", "Run"),
+        ("run", "Run"),
+        ("Trail Run", "Run"),
+        ("Ride", "Ride"),
+        ("VirtualRide", "Ride"),
+        ("Cycling", "Ride"),
+        ("Swim", "Swim"),
+        ("OpenWaterSwim", "Swim"),
+        (None, "Run"),
+        ("", "Run"),
+        ("Walk", "Run"),  # unknown → default Run
+    ],
+)
+def test_get_sport_type(event_type, expected):
+    assert _get_sport_type(event_type) == expected
+
+
+# ---------------------------------------------------------------------------
+# create_event — auto_translate=True (default)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateEventAutoTranslate:
+    """create_event with auto_translate=True (default)."""
+
+    async def test_translates_finalsurge_description(self, mock_config, respx_mock):
+        """A structured FinalSurge description is translated before being sent to the API."""
+        finalsurge_desc = "Easy running throughout 6-8x( 15-20s @ Stride / Fast (Z5) Full recovery easy jog )"
+        duration = 2700  # 45 minutes
+
+        # The API receives whatever description was POSTed; echo it back
+        def _echo_handler(request):
+            body = json.loads(request.content)
+            return Response(
+                200,
+                json=_make_event_response(
+                    description=body.get("description"),
+                    moving_time=body.get("moving_time"),
+                ),
+            )
+
+        respx_mock.post(EVENTS_URL).mock(side_effect=_echo_handler)
+
+        result = await create_event(
+            start_date="2026-04-10",
+            name="Strides Run",
+            category="WORKOUT",
+            description=finalsurge_desc,
+            event_type="Run",
+            duration_seconds=duration,
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        # Description in the response should be the translated ICU format
+        translated_desc = response["data"]["description"]
+        assert "7x" in translated_desc, f"Expected 7x repeat block, got:\n{translated_desc}"
+        assert "- 17s z5 pace" in translated_desc
+        # Metadata must confirm translation happened
+        assert response["metadata"]["description_translated"] is True
+        assert "original_description" in response["metadata"]
+        assert response["metadata"]["original_description"] == finalsurge_desc
+
+    async def test_inline_repeat_pattern_translated(self, mock_config, respx_mock):
+        """The new inline 'N x work and recovery' pattern is translated."""
+        desc = "8 x 4:00mins @MP->HMP and 2:00mins easy"
+        duration = 4800  # 1h20m
+
+        def _echo_handler(request):
+            body = json.loads(request.content)
+            return Response(200, json=_make_event_response(description=body.get("description")))
+
+        respx_mock.post(EVENTS_URL).mock(side_effect=_echo_handler)
+
+        result = await create_event(
+            start_date="2026-04-10",
+            name="MP Intervals",
+            category="WORKOUT",
+            description=desc,
+            event_type="Run",
+            duration_seconds=duration,
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        translated = response["data"]["description"]
+        assert "8x" in translated
+        assert "- 4m z4 pace" in translated
+        assert response["metadata"]["description_translated"] is True
+
+    async def test_no_translation_when_description_unchanged(self, mock_config, respx_mock):
+        """When the translator produces the same text as the input, description_translated=False.
+
+        A single-step ICU description like '- 30m z2 pace' contains no repeat pattern,
+        so _build_simple re-produces the same string and the flag stays False.
+        """
+        # "- 30m z2 pace" → _identify_intensity finds "z2", _seconds_to_icu(1800)="30m"
+        # → translate_workout returns "- 30m z2 pace" == original → no change
+        already_icu = "- 30m z2 pace"
+
+        respx_mock.post(EVENTS_URL).mock(
+            return_value=Response(200, json=_make_event_response(description=already_icu))
+        )
+
+        result = await create_event(
+            start_date="2026-04-10",
+            name="Easy Run",
+            category="WORKOUT",
+            description=already_icu,
+            event_type="Run",
+            duration_seconds=1800,
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        assert response["metadata"].get("description_translated") is False
+
+    async def test_no_translation_without_duration(self, mock_config, respx_mock):
+        """No translation is attempted when duration_seconds is absent."""
+        desc = "6-8x( 15-20s @ Stride / Full recovery )"
+
+        respx_mock.post(EVENTS_URL).mock(
+            return_value=Response(200, json=_make_event_response(description=desc))
+        )
+
+        result = await create_event(
+            start_date="2026-04-10",
+            name="Strides",
+            category="WORKOUT",
+            description=desc,
+            event_type="Run",
+            duration_seconds=None,  # no duration → no translation
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        # No translation metadata should be present at all
+        assert "description_translated" not in response["metadata"]
+
+    async def test_no_translation_for_non_workout_category(self, mock_config, respx_mock):
+        """Non-WORKOUT categories (NOTE, RACE, GOAL) are never translated."""
+        desc = "Easy running 6-8x( 15s strides )"
+
+        respx_mock.post(EVENTS_URL).mock(
+            return_value=Response(200, json=_make_event_response(category="NOTE", description=desc))
+        )
+
+        result = await create_event(
+            start_date="2026-04-10",
+            name="Race note",
+            category="NOTE",
+            description=desc,
+            duration_seconds=3600,
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        assert "description_translated" not in response["metadata"]
+
+    async def test_sport_type_ride_uses_power_context(self, mock_config, respx_mock):
+        """Ride events pass sport_type='Ride' to the translator (no crash)."""
+        desc = "30min easy"
+
+        respx_mock.post(EVENTS_URL).mock(
+            return_value=Response(
+                200,
+                json=_make_event_response(event_type="Ride", description="- 30m z2 pace"),
+            )
+        )
+
+        result = await create_event(
+            start_date="2026-04-10",
+            name="Easy Ride",
+            category="WORKOUT",
+            description=desc,
+            event_type="Ride",
+            duration_seconds=1800,
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+        assert response["data"]["type"] == "Ride"
+
+
+# ---------------------------------------------------------------------------
+# create_event — auto_translate=False
+# ---------------------------------------------------------------------------
+
+
+class TestCreateEventNoTranslate:
+    """create_event with auto_translate=False."""
+
+    async def test_description_sent_verbatim(self, mock_config, respx_mock):
+        """When auto_translate=False, the raw description reaches the API unchanged."""
+        finalsurge_desc = "Easy running throughout 7x( 17s @ Stride / Full recovery easy jog )"
+
+        captured: dict = {}
+
+        def _capture_handler(request):
+            captured["body"] = json.loads(request.content)
+            return Response(
+                200,
+                json=_make_event_response(description=finalsurge_desc),
+            )
+
+        respx_mock.post(EVENTS_URL).mock(side_effect=_capture_handler)
+
+        await create_event(
+            start_date="2026-04-10",
+            name="Strides",
+            category="WORKOUT",
+            description=finalsurge_desc,
+            event_type="Run",
+            duration_seconds=2700,
+            auto_translate=False,
+            ctx=_make_ctx(mock_config),
+        )
+
+        assert captured["body"]["description"] == finalsurge_desc
+
+    async def test_no_translation_metadata_in_response(self, mock_config, respx_mock):
+        """No translation metadata is present when auto_translate=False."""
+        respx_mock.post(EVENTS_URL).mock(
+            return_value=Response(200, json=_make_event_response())
+        )
+
+        result = await create_event(
+            start_date="2026-04-10",
+            name="Easy Run",
+            category="WORKOUT",
+            description="30min easy",
+            event_type="Run",
+            duration_seconds=1800,
+            auto_translate=False,
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        assert "description_translated" not in response["metadata"]
+
+
+# ---------------------------------------------------------------------------
+# bulk_create_events — auto_translate
+# ---------------------------------------------------------------------------
+
+
+class TestBulkCreateEventsAutoTranslate:
+    """bulk_create_events with and without auto_translate."""
+
+    def _make_bulk_payload(self) -> list[dict]:
+        return [
+            {
+                "start_date_local": "2026-04-10",
+                "name": "Strides Run",
+                "category": "WORKOUT",
+                "type": "Run",
+                "description": "Easy running throughout 6-8x( 15-20s @ Stride / Fast (Z5) Full recovery easy jog )",
+                "moving_time": 2700,
+            },
+            {
+                "start_date_local": "2026-04-11",
+                "name": "Easy Run",
+                "category": "WORKOUT",
+                "type": "Run",
+                "description": "30min easy",
+                "moving_time": 1800,
+            },
+            {
+                "start_date_local": "2026-04-12",
+                "name": "Race Note",
+                "category": "NOTE",
+                "description": "Remember to bring gels",
+            },
+        ]
+
+    async def test_translates_eligible_workout_events(self, mock_config, respx_mock):
+        """Eligible WORKOUT events have their descriptions translated; NOTE is untouched."""
+        payload = self._make_bulk_payload()
+        captured: dict = {}
+
+        def _capture_handler(request):
+            captured["body"] = json.loads(request.content)
+            # Echo back minimal event objects
+            return Response(
+                200,
+                json=[
+                    _make_event_response(event_id=i + 1, description=e.get("description"))
+                    for i, e in enumerate(captured["body"])
+                ],
+            )
+
+        respx_mock.post(BULK_EVENTS_URL).mock(side_effect=_capture_handler)
+
+        result = await bulk_create_events(
+            events=json.dumps(payload),
+            auto_translate=True,
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        assert "data" in response
+
+        # The strides workout (index 0) should have been translated
+        sent_events = captured["body"]
+        strides_desc = sent_events[0]["description"]
+        assert "7x" in strides_desc, f"Expected 7x block, got:\n{strides_desc}"
+        assert "- 17s z5 pace" in strides_desc
+
+        # The easy run (index 1) — "30min easy" → single step, may or may not change
+        # Just verify it didn't crash and is a string
+        assert isinstance(sent_events[1]["description"], str)
+
+        # The NOTE (index 2) must be untouched
+        assert sent_events[2]["description"] == "Remember to bring gels"
+
+        # translated_count must be at least 1 (the strides workout)
+        assert response["metadata"]["translated_count"] >= 1
+
+    async def test_no_translation_when_flag_false(self, mock_config, respx_mock):
+        """With auto_translate=False all descriptions reach the API verbatim."""
+        payload = self._make_bulk_payload()
+        captured: dict = {}
+
+        def _capture_handler(request):
+            captured["body"] = json.loads(request.content)
+            return Response(
+                200,
+                json=[
+                    _make_event_response(event_id=i + 1)
+                    for i in range(len(captured["body"]))
+                ],
+            )
+
+        respx_mock.post(BULK_EVENTS_URL).mock(side_effect=_capture_handler)
+
+        await bulk_create_events(
+            events=json.dumps(payload),
+            auto_translate=False,
+            ctx=_make_ctx(mock_config),
+        )
+
+        original_descs = [e.get("description") for e in payload]
+        sent_descs = [e.get("description") for e in captured["body"]]
+        assert sent_descs == original_descs
+
+    async def test_translated_count_zero_when_no_eligible_events(
+        self, mock_config, respx_mock
+    ):
+        """translated_count is 0 when no events qualify for translation."""
+        payload = [
+            {
+                "start_date_local": "2026-04-10",
+                "name": "Easy Run",
+                "category": "WORKOUT",
+                "type": "Run",
+                # No description → not eligible
+                "moving_time": 1800,
+            }
+        ]
+
+        respx_mock.post(BULK_EVENTS_URL).mock(
+            return_value=Response(200, json=[_make_event_response()])
+        )
+
+        result = await bulk_create_events(
+            events=json.dumps(payload),
+            auto_translate=True,
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        assert response["metadata"]["translated_count"] == 0
+
+    async def test_inline_repeat_pattern_in_bulk(self, mock_config, respx_mock):
+        """The inline 'N x work and recovery' pattern is translated in bulk mode."""
+        payload = [
+            {
+                "start_date_local": "2026-04-10",
+                "name": "MP Intervals",
+                "category": "WORKOUT",
+                "type": "Run",
+                "description": "8 x 4:00mins @MP->HMP and 2:00mins easy",
+                "moving_time": 4800,
+            }
+        ]
+        captured: dict = {}
+
+        def _capture_handler(request):
+            captured["body"] = json.loads(request.content)
+            return Response(200, json=[_make_event_response()])
+
+        respx_mock.post(BULK_EVENTS_URL).mock(side_effect=_capture_handler)
+
+        result = await bulk_create_events(
+            events=json.dumps(payload),
+            auto_translate=True,
+            ctx=_make_ctx(mock_config),
+        )
+
+        response = json.loads(result)
+        sent_desc = captured["body"][0]["description"]
+        assert "8x" in sent_desc
+        assert "- 4m z4 pace" in sent_desc
+        assert response["metadata"]["translated_count"] == 1

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,533 @@
+"""Tests for the FinalSurge → Intervals.icu workout translator."""
+
+import pytest
+
+from intervals_icu_mcp.workout_translator import (
+    _seconds_to_icu,
+    _map_intensity,
+    translate_workout,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit: duration formatting
+# ---------------------------------------------------------------------------
+
+
+def test_seconds_to_icu_seconds_only():
+    assert _seconds_to_icu(17) == "17s"
+
+
+def test_seconds_to_icu_minutes_only():
+    assert _seconds_to_icu(600) == "10m"
+
+
+def test_seconds_to_icu_minutes_and_seconds():
+    assert _seconds_to_icu(105) == "1m45s"
+
+
+def test_seconds_to_icu_hours_minutes_seconds():
+    assert _seconds_to_icu(3750) == "1h2m30s"
+
+
+def test_seconds_to_icu_zero():
+    assert _seconds_to_icu(0) == "0s"
+
+
+# ---------------------------------------------------------------------------
+# Unit: intensity mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("easy", "z2 pace"),
+        ("Easy", "z2 pace"),
+        ("recovery", "z1 pace"),
+        ("stride", "z5 pace"),
+        ("fast", "z5 pace"),
+        ("threshold", "z4 pace"),
+        ("HMP", "z4 pace"),
+        ("tempo", "z3 pace"),
+        ("sprint", "z6 pace"),
+        ("z3", "z3 pace"),
+        ("Z5", "z5 pace"),
+        ("Z1-Z2", "z2 pace"),
+        ("unknown_term", "z2 pace"),  # default
+    ],
+)
+def test_intensity_mapping(raw, expected):
+    assert _map_intensity(raw) == expected
+
+
+# ---------------------------------------------------------------------------
+# Integration: translate_workout (design doc test cases)
+# ---------------------------------------------------------------------------
+
+
+def test_simple_easy_run():
+    result = translate_workout("30min easy", 1800)
+    assert result == "- 30m z2 pace"
+
+
+def test_strides_workout():
+    """6-8x strides → 7x, 15-20s → 17s, inferred full recovery."""
+    description = "Easy running throughout 6-8x( 15-20s @ Stride / Fast (Z5) Full recovery easy jog )"
+    result = translate_workout(description, duration_seconds=2700)
+
+    lines = result.strip().splitlines()
+    # Find the Nx line index
+    nx_idx = next(i for i, l in enumerate(lines) if re.fullmatch(r"\d+x", l.strip()))
+    # Blank line precedes interval block
+    assert lines[nx_idx - 1] == ""
+    # Optional base run before blank line
+    if nx_idx >= 2:
+        assert lines[0].startswith("- ")
+        assert "z2 pace" in lines[0]
+    # Repeat count
+    assert lines[nx_idx] == "7x"
+    # Work step
+    assert lines[nx_idx + 1] == "- 17s z5 pace"
+    # Recovery step exists and has z1/z2 intensity (inferred from "easy jog")
+    assert lines[nx_idx + 2].startswith("- ")
+    assert "z2 pace" in lines[nx_idx + 2] or "z1 pace" in lines[nx_idx + 2]
+
+
+def test_structured_warmup_intervals_cooldown():
+    """15:00 warm-up, 2x(10:00 @ HMP, 5:00 recovery), 5:00 cooldown."""
+    description = "15:00 Easy (Z1-Z2) 2x( 10:00 @ HMP (Z4) 5:00 Walk / Easy Jog recovery ) 5:00 Easy (Z1-Z2)"
+    result = translate_workout(description, duration_seconds=2700)
+
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 15m z2 pace", f"Expected warmup, got: {lines[0]}"
+    assert lines[1] == ""
+    assert lines[2] == "2x"
+    assert lines[3] == "- 10m z4 pace", f"Expected work step, got: {lines[3]}"
+    assert lines[4] == "- 5m z2 pace", f"Expected recovery step, got: {lines[4]}"
+    assert lines[5] == ""
+    assert lines[6] == "- 5m z2 pace", f"Expected cooldown, got: {lines[6]}"
+
+
+def test_translation_fallback_on_bad_input():
+    """If description is completely unparseable, return original."""
+    bad = "##@@@!!! no duration no intensity ###"
+    result = translate_workout(bad, duration_seconds=1800)
+    # Either returns original OR a valid fallback - should not raise
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_range_reps_rounded_down():
+    """4-6x → 5x (midpoint)."""
+    description = "4-6x( 1m z4 pace / 2m z2 pace )"
+    result = translate_workout(description, duration_seconds=1800)
+    lines = result.strip().splitlines()
+    # Find the Nx line
+    nx_lines = [l for l in lines if re.fullmatch(r"\d+x", l.strip())]
+    assert nx_lines, "Expected an Nx line"
+    assert nx_lines[0] == "5x"
+
+
+def test_threshold_intensity():
+    description = "10min @threshold"
+    result = translate_workout(description, duration_seconds=600)
+    assert result == "- 10m z4 pace"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: inline "N x work [sep] recovery" prose/bullet patterns
+# ---------------------------------------------------------------------------
+
+
+def test_inline_repeat_with_arrow_intensity():
+    """8 x 4:00mins @MP->HMP and 2:00mins easy → 8x block, @MP->HMP = z4 pace target."""
+    # 8 × (4m work + 2m recovery) = 48m; total 1h20m → 32m base run
+    description = "8 x 4:00mins @MP->HMP and 2:00mins easy"
+    result = translate_workout(description, duration_seconds=4800)  # 1h20m
+
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 32m z2 pace", f"Expected base run, got: {lines[0]}"
+    assert lines[1] == ""
+    assert lines[2] == "8x"
+    assert lines[3] == "- 4m z4 pace", f"Expected work z4, got: {lines[3]}"
+    assert lines[4] == "- 2m z2 pace", f"Expected recovery z2, got: {lines[4]}"
+
+
+def test_inline_repeat_at_mp_with_rest():
+    """4 x 15mins at MP with 5 mins rest → 4x block."""
+    # 4 × (15m + 5m) = 80m; total 2h10m = 130m → 50m base run
+    description = "4 x 15mins at MP with 5 mins rest"
+    result = translate_workout(description, duration_seconds=7800)  # 2h10m
+
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 50m z2 pace", f"Expected base run, got: {lines[0]}"
+    assert lines[1] == ""
+    assert lines[2] == "4x"
+    assert lines[3] == "- 15m z3 pace", f"Expected work z3 (MP), got: {lines[3]}"
+    assert lines[4] == "- 5m z1 pace", f"Expected recovery z1 (rest), got: {lines[4]}"
+
+
+def test_inline_repeat_bullet_prefix():
+    """Bullet-prefixed line: '- 8 x 4:00mins @MP' is recognised as an 8x block."""
+    description = "- 8 x 4:00mins @MP"
+    result = translate_workout(description, duration_seconds=4800)  # 1h20m
+
+    lines = result.strip().splitlines()
+    # Should have base run + blank + 8x + work step
+    nx_idx = next(i for i, l in enumerate(lines) if re.fullmatch(r"\d+x", l.strip()))
+    assert lines[nx_idx] == "8x"
+    assert lines[nx_idx + 1] == "- 4m z3 pace", f"Expected z3 (MP), got: {lines[nx_idx + 1]}"
+
+
+def test_inline_repeat_range_reps():
+    """6-8 x 4:00mins at HMP and 2:00mins easy → 7x (midpoint rounded down)."""
+    description = "6-8 x 4:00mins at HMP and 2:00mins easy"
+    result = translate_workout(description, duration_seconds=4200)  # 70m
+
+    lines = result.strip().splitlines()
+    nx_idx = next(i for i, l in enumerate(lines) if re.fullmatch(r"\d+x", l.strip()))
+    assert lines[nx_idx] == "7x"
+    assert "z4 pace" in lines[nx_idx + 1]  # HMP = z4
+
+
+def test_inline_repeat_no_recovery():
+    """N x work with no recovery segment — no recovery step emitted."""
+    description = "5 x 3:00mins @threshold"
+    # 5 × 3m = 15m; total 30m → 15m base run
+    result = translate_workout(description, duration_seconds=1800)
+
+    lines = result.strip().splitlines()
+    nx_idx = next(i for i, l in enumerate(lines) if re.fullmatch(r"\d+x", l.strip()))
+    assert lines[nx_idx] == "5x"
+    assert lines[nx_idx + 1] == "- 3m z4 pace"
+    # No recovery line after work step
+    assert nx_idx + 2 == len(lines)
+
+
+def test_mp_intensity_mapping():
+    """'MP' and 'marathon pace' map to z3 pace."""
+    from intervals_icu_mcp.workout_translator import _identify_intensity
+
+    assert _identify_intensity("at MP", "Run") == "z3 pace"
+    assert _identify_intensity("@MP", "Run") == "z3 pace"
+    assert _identify_intensity("marathon pace", "Run") == "z3 pace"
+
+
+def test_arrow_intensity_range():
+    """'@MP->HMP' resolves to z4 pace (target/right side of arrow)."""
+    from intervals_icu_mcp.workout_translator import _identify_intensity
+
+    assert _identify_intensity("@MP->HMP", "Run") == "z4 pace"
+    assert _identify_intensity("z3->z4", "Run") == "z4 pace"
+
+
+import re  # noqa: E402 (used in tests above)
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 pre-work: multi-line bullet-list parser
+# ---------------------------------------------------------------------------
+
+
+def test_bullet_list_pure_multi_step():
+    """Pure bullet list with no Nx → one step per bullet."""
+    description = (
+        "- 20 mins warm up Easy\n"
+        "- 20 mins at marathon pace\n"
+        "- 5 mins easy jog\n"
+        "- 10 mins at MP\n"
+        "- 5 mins cool down"
+    )
+    result = translate_workout(description, duration_seconds=3600)
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 20m z2 pace"
+    assert lines[1] == "- 20m z3 pace"
+    assert lines[2] == "- 5m z2 pace"
+    assert lines[3] == "- 10m z3 pace"
+    assert lines[4] == "- 5m z2 pace"
+    assert len(lines) == 5
+
+
+def test_bullet_list_full_75min_workout():
+    """Full 7-bullet 75-min workout from translation doc."""
+    description = (
+        "- 20 mins warm up Easy\n"
+        "- 20 mins at marathon pace (effort)\n"
+        "- 5 mins easy jog or walking\n"
+        "- 10 mins at marathon pace (effort)\n"
+        "- 5 mins easy jog or walking\n"
+        "- 5 mins at half marathon pace\n"
+        "- 10 mins cool down easy"
+    )
+    result = translate_workout(description, duration_seconds=4500)
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 20m z2 pace"
+    assert lines[1] == "- 20m z3 pace"
+    assert lines[2] == "- 5m z2 pace"
+    assert lines[3] == "- 10m z3 pace"
+    assert lines[4] == "- 5m z2 pace"
+    assert lines[5] == "- 5m z4 pace"
+    assert lines[6] == "- 10m z2 pace"
+    assert len(lines) == 7
+
+
+def test_bullet_list_with_embedded_nx():
+    """Bullet list where one bullet contains a '2 x work with recovery' pattern."""
+    description = (
+        "- 45 mins easy\n"
+        "- 2 x 40mins@MP with 10 mins easy rest in between\n"
+        "- 15 mins easy"
+    )
+    result = translate_workout(description, duration_seconds=9000)
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 45m z2 pace"
+    assert lines[1] == ""
+    assert lines[2] == "2x"
+    assert lines[3] == "- 40m z3 pace"
+    assert lines[4] == "- 10m z1 pace"  # "easy rest" → z1 (recovery, not z2)
+    assert lines[5] == ""
+    assert lines[6] == "- 15m z2 pace"
+
+
+def test_bullet_list_embedded_nx_with_pace_annotation():
+    """'2 x 40mins@MP(8:40-55)' — pace annotation in parens must not confuse parser."""
+    description = (
+        "- 45 mins easy\n"
+        "- 2 x 40mins@MP(8:40-55) with 10 mins easy rest in between\n"
+        "- 15 mins easy"
+    )
+    result = translate_workout(description, duration_seconds=9000)
+    lines = result.strip().splitlines()
+    assert lines[2] == "2x"
+    assert lines[3] == "- 40m z3 pace"
+    assert lines[4] == "- 10m z1 pace"  # "easy rest" → z1
+
+
+def test_single_bullet_not_parsed_as_list():
+    """A single bullet line must NOT activate the bullet-list parser."""
+    result = translate_workout("- 8 x 4:00mins @MP", duration_seconds=4800)
+    lines = result.strip().splitlines()
+    nx_idx = next(i for i, l in enumerate(lines) if re.fullmatch(r"\d+x", l.strip()))
+    assert lines[nx_idx] == "8x"
+    assert lines[nx_idx + 1] == "- 4m z3 pace"
+
+
+# ---------------------------------------------------------------------------
+# Strides / pickups template
+# ---------------------------------------------------------------------------
+
+
+def test_strides_keyword_applies_template():
+    """'pickups' in description → 5x(15s z5 / 1m45s z1) template."""
+    description = "Run 6-8 x 100m or 15-20s pickups, with full recovery"
+    result = translate_workout(description, duration_seconds=1800)  # 30 min
+    lines = result.strip().splitlines()
+    # 30 min total − 10 min intervals = 20 min base run
+    assert lines[0] == "- 20m z2 pace"
+    assert lines[1] == ""
+    assert lines[2] == "5x"
+    assert lines[3] == "- 15s z5 pace"
+    assert lines[4] == "- 1m45s z1 pace"
+
+
+def test_strides_45min_workout():
+    """Same description at 45 min → 35 min base run."""
+    description = "Run 6-8 x 100m or 15-20s pickups, with full recovery"
+    result = translate_workout(description, duration_seconds=2700)  # 45 min
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 35m z2 pace"
+    assert lines[2] == "5x"
+    assert lines[3] == "- 15s z5 pace"
+    assert lines[4] == "- 1m45s z1 pace"
+
+
+def test_explicit_zone_in_strides_skips_template():
+    """When description already has Z5 annotation, paren-form parser wins."""
+    # This is the existing test_strides_workout scenario repackaged.
+    description = "Easy running throughout 6-8x( 15-20s @ Stride / Fast (Z5) Full recovery easy jog )"
+    result = translate_workout(description, duration_seconds=2700)
+    lines = result.strip().splitlines()
+    nx_idx = next(i for i, l in enumerate(lines) if re.fullmatch(r"\d+x", l.strip()))
+    # Paren-form handled it: 7x, 17s z5
+    assert lines[nx_idx] == "7x"
+    assert lines[nx_idx + 1] == "- 17s z5 pace"
+
+
+# ---------------------------------------------------------------------------
+# Recovery intensity fix: 'easy jog rest' → z1, not z2
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_jog_rest_maps_to_z1():
+    """'walk/easy jog rest' in recovery segment → z1 pace, not z2."""
+    description = "15 mins easy + 2 x 10mins at HMP with 5 mins walk/easy jog rest + 5 mins easy"
+    result = translate_workout(description, duration_seconds=2700)
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 15m z2 pace"
+    assert lines[1] == ""
+    assert lines[2] == "2x"
+    assert lines[3] == "- 10m z4 pace"
+    assert lines[4] == "- 5m z1 pace", f"Expected z1 recovery, got: {lines[4]}"
+
+
+def test_easy_jog_rest_intensity():
+    """Isolated check: 'easy jog rest' string resolves to z1 via INTENSITY_MAP."""
+    from intervals_icu_mcp.workout_translator import _identify_intensity
+
+    assert _identify_intensity("walk/easy jog rest", "Run") == "z1 pace"
+    assert _identify_intensity("easy jog rest", "Run") == "z1 pace"
+    assert _identify_intensity("walk rest", "Run") == "z1 pace"
+
+
+# ---------------------------------------------------------------------------
+# Phase 5a — P4: on/off intensity keywords
+# ---------------------------------------------------------------------------
+
+
+def test_on_off_intensity_mapping():
+    """'on' maps to z5, 'off' maps to z1."""
+    from intervals_icu_mcp.workout_translator import _map_intensity
+
+    assert _map_intensity("on") == "z5 pace"
+    assert _map_intensity("off") == "z1 pace"
+    assert _map_intensity("On") == "z5 pace"
+    assert _map_intensity("OFF") == "z1 pace"
+
+
+def test_on_off_workout_translation():
+    """'4-6 x 30s on / 2 mins off' → 5x, 30s z5, 2m z1."""
+    description = "- 4-6 x 30s on / 2 mins off"
+    result = translate_workout(description, duration_seconds=4800)
+    lines = result.strip().splitlines()
+    nx_idx = next(i for i, l in enumerate(lines) if re.fullmatch(r"\d+x", l.strip()))
+    assert lines[nx_idx] == "5x"
+    assert lines[nx_idx + 1] == "- 30s z5 pace", f"Expected z5 work, got: {lines[nx_idx + 1]}"
+    assert lines[nx_idx + 2] == "- 2m z1 pace", f"Expected z1 recovery, got: {lines[nx_idx + 2]}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 5a — P1: meters vs. minutes disambiguation
+# ---------------------------------------------------------------------------
+
+
+def test_meter_detection_no_absurd_duration():
+    """'200m@HMP' must NOT produce a 200-minute duration — falls to simple fallback."""
+    description = "- 4 x 200m@HMP with 200m jog rest"
+    result = translate_workout(description, duration_seconds=2400)
+    # Result must not contain multi-hour absurdities like "3h20m"
+    assert "3h" not in result, f"Meter misparse not caught: {result}"
+    assert "200m" not in result or "pace" in result  # either cleaned up or left as fallback
+
+
+def test_meter_detection_cutdown():
+    """Distance-based cutdown (1600m, 1200m …) falls back to simple rather than multi-hour nonsense."""
+    description = (
+        "- 1600m@Tempo->10k\n"
+        "- 1200m@10k\n"
+        "- 800m@5k\n"
+        "- 400m@3k"
+    )
+    result = translate_workout(description, duration_seconds=3600)
+    # Must not contain anything like "26h40m" from 1600m → 1600 min
+    assert "h40m" not in result, f"Meter misparse: {result}"
+    assert "20h" not in result, f"Meter misparse: {result}"
+
+
+def test_is_meters_not_minutes():
+    """Unit test for the _is_meters_not_minutes helper."""
+    from intervals_icu_mcp.workout_translator import _is_meters_not_minutes
+
+    assert _is_meters_not_minutes(200) is True
+    assert _is_meters_not_minutes(400) is True
+    assert _is_meters_not_minutes(800) is True
+    assert _is_meters_not_minutes(1600) is True
+    assert _is_meters_not_minutes(5000) is True
+    assert _is_meters_not_minutes(91) is True   # > threshold
+    assert _is_meters_not_minutes(30) is False  # valid minutes
+    assert _is_meters_not_minutes(45) is False
+    assert _is_meters_not_minutes(60) is False
+    assert _is_meters_not_minutes(90) is False  # exactly at threshold boundary — still ok as min
+
+
+# ---------------------------------------------------------------------------
+# Phase 5a — P2: commentary-bullet filter
+# ---------------------------------------------------------------------------
+
+
+def test_commentary_bullets_filtered():
+    """Coaching-cue bullets are dropped; only workout steps survive."""
+    description = (
+        "- Total Time: 2:30-2:45\n"
+        "- Hitting total time is first priority\n"
+        "- 45 mins easy\n"
+        "- 2 x 40mins@MP with 10 mins easy rest in between\n"
+        "- 15-30 mins easy\n"
+        "- If you are feeling good, add 15 more minutes"
+    )
+    result = translate_workout(description, duration_seconds=9000)
+    lines = result.strip().splitlines()
+    # "Total Time" and "Hitting..." and "If..." bullets should NOT appear as steps
+    assert not any("2m45s" in l for l in lines), f"Commentary bled into steps: {result}"
+    # Core workout should still be there
+    assert lines[0] == "- 45m z2 pace", f"Expected warmup, got: {lines[0]}"
+    nx_idx = next(i for i, l in enumerate(lines) if re.fullmatch(r"\d+x", l.strip()))
+    assert lines[nx_idx] == "2x"
+    assert lines[nx_idx + 1] == "- 40m z3 pace"
+
+
+def test_commentary_bullet_helper():
+    """Unit test for _is_commentary_bullet."""
+    from intervals_icu_mcp.workout_translator import _is_commentary_bullet
+
+    assert _is_commentary_bullet("Total Time: 2:30") is True
+    assert _is_commentary_bullet("If you are feeling good, add more") is True
+    assert _is_commentary_bullet("Priority is the weekend workout") is True
+    assert _is_commentary_bullet("Start slower than you think") is True
+    assert _is_commentary_bullet("Hitting total time is first priority") is True
+    assert _is_commentary_bullet("only do 2:45 if feeling good") is True
+    assert _is_commentary_bullet("45 mins easy") is False
+    assert _is_commentary_bullet("2 x 40mins@MP with 10 mins rest") is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 5a — P3: non-bullet multi-segment plain descriptions
+# ---------------------------------------------------------------------------
+
+
+def test_plain_segments_last_workout():
+    """'Last Workout!' style: three plain-text lines, no bullets → parsed as segments."""
+    description = (
+        "45 mins easy to moderate\n"
+        "30mins at goal marathon pace\n"
+        "15 mins cool down\n"
+        "\n"
+        "If feeling tired, shorten even more!"
+    )
+    result = translate_workout(description, duration_seconds=5400)
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 45m z2 pace", f"Got: {lines[0]}"
+    assert lines[1] == "- 30m z3 pace", f"Got: {lines[1]}"
+    assert lines[2] == "- 15m z2 pace", f"Got: {lines[2]}"
+    assert len(lines) == 3
+
+
+def test_plain_segments_requires_two_lines():
+    """A single plain line does NOT activate the plain-segments parser."""
+    result = translate_workout("45 mins easy", duration_seconds=2700)
+    # Should be handled by _build_simple, not plain_segments
+    assert result == "- 45m z2 pace"
+
+
+def test_plain_segments_skips_commentary_lines():
+    """Commentary lines among plain segments are silently skipped."""
+    description = (
+        "45 mins easy\n"
+        "If feeling tired, cut this short\n"
+        "15 mins cool down"
+    )
+    result = translate_workout(description, duration_seconds=3600)
+    lines = result.strip().splitlines()
+    assert lines[0] == "- 45m z2 pace"
+    assert lines[1] == "- 15m z2 pace"
+    assert len(lines) == 2

--- a/workout_translation_design.md
+++ b/workout_translation_design.md
@@ -1,0 +1,524 @@
+# Workout Translation Function Design
+## FinalSurge → Intervals.icu Structured Format
+
+### Problem Statement
+Coach workouts in FinalSurge are often descriptive/natural language rather than strictly structured. Need automated translation to Intervals.icu's strict plain-text workout format.
+
+### Example Transformation
+
+**Input** (FinalSurge):
+```
+Name: Easy Run with Strides
+Duration: 45 minutes
+Description: "Easy running throughout 6-8x( 15-20s @ Stride / Fast (Z5) Full recovery easy jog )"
+```
+
+**Output** (Intervals.icu format):
+```
+- 18m z2 pace
+
+6x
+- 15s z5 pace
+- 1m45s z2 pace
+```
+
+### Intervals.icu Format Rules (from documentation)
+
+#### Core Syntax
+```
+- [duration/distance] [intensity] [optional_cadence]
+```
+
+#### Duration formats
+- Hours: `1h`
+- Minutes: `10m`, `5m`
+- Seconds: `30s`, `90s`
+- Combined: `1m30s`, `1h2m30s`
+- Shorthand: `5'`, `30"`, `1'30"`
+
+#### Intensity formats (Running)
+- Zones: `z1 pace`, `z2 pace`, `z3 pace`, `z4 pace`, `z5 pace`
+- Percentages: `78-82% pace`, `90% pace`
+- Heart rate: `70% HR`, `75-80% HR`, `Z2 HR`
+
+#### Repeat syntax
+Two valid forms:
+1. Header style: `Main Set 6x`
+2. Standalone: `6x` (on its own line before the repeated block)
+
+#### Critical formatting rules
+- Steps start with `-` (dash + space)
+- Blank lines surround interval blocks (before and after `Nx` repeats)
+- **Nested repeats NOT supported** - intervals must be flat
+- Section headers: lines without `-`
+- Free text allowed anywhere; text before first duration/intensity becomes the step cue
+
+### Workflow Integration Points
+
+#### Option 1: Pre-processing in MCP Server (RECOMMENDED)
+```
+FinalSurge API → parse_workout() → translate_workout() → create_event() → Intervals.icu API
+```
+
+**Location**: New function in MCP server
+**Function signature**:
+```python
+def translate_workout(
+    description: str,
+    duration_seconds: int,
+    sport_type: str = "Run"
+) -> str:
+    """
+    Translate FinalSurge descriptive workout into Intervals.icu format.
+
+    Args:
+        description: Natural language workout description from FinalSurge
+        duration_seconds: Total workout duration in seconds
+        sport_type: "Run", "Ride", or "Swim"
+
+    Returns:
+        Intervals.icu formatted workout string
+    """
+```
+
+**Advantages**:
+- Single source of truth for translation logic
+- Reusable across bulk/single create operations
+- Can be tested independently
+- Doesn't require Claude for every workout
+
+#### Option 2: Claude-assisted translation
+```
+FinalSurge API → MCP → Claude (translate) → MCP (create) → Intervals.icu API
+```
+
+**Advantages**:
+- Handles complex/ambiguous descriptions better
+- Can learn from corrections
+- More flexible with varied formats
+
+**Disadvantages**:
+- Requires API call per workout
+- Latency
+- Token costs
+
+### Translation Logic Design
+
+#### 1. Parsing strategy
+```python
+class WorkoutParser:
+    def parse(self, description: str, duration_seconds: int):
+        """Extract workout components"""
+        # Identify intervals pattern: "Nx(...)" or "N-Mx(...)"
+        intervals = self.extract_intervals(description)
+
+        # Identify intensity markers: "Z1-Z5", "@HMP", "@threshold", "easy", "fast"
+        intensities = self.extract_intensities(description)
+
+        # Identify duration markers: "15-20s", "10min", etc.
+        durations = self.extract_durations(description)
+
+        # Calculate remaining time (total - intervals = base run)
+        base_duration = self.calculate_base(duration_seconds, intervals, durations)
+
+        return WorkoutComponents(intervals, intensities, durations, base_duration)
+```
+
+#### 2. Range resolution rules
+```python
+RANGE_RESOLUTION_RULES = {
+    "reps": {
+        "strategy": "midpoint_rounded_down",
+        # "6-8x" → 7x (round down from 7.0)
+        # "4-6x" → 5x
+    },
+    "duration": {
+        "strategy": "midpoint",
+        # "15-20s" → 17s (average)
+        # "10-15m" → 12m30s
+    },
+    "recovery": {
+        "strategy": "calculated",
+        # "Full recovery" → calculate from: (total_time - work_time) / reps
+    }
+}
+```
+
+#### 3. Intensity mapping
+```python
+INTENSITY_MAP = {
+    # FinalSurge terms → Intervals.icu format
+    "easy": "z2 pace",
+    "recovery": "z1 pace",
+    "easy jog": "z2 pace",
+    "hmp": "z4 pace",  # Half marathon pace
+    "threshold": "z4 pace",
+    "tempo": "z3 pace",
+    "stride": "z5 pace",
+    "fast": "z5 pace",
+    "sprint": "z6 pace",
+    "on": "z5 pace",   # "30s on" → hard effort
+    "off": "z1 pace",  # "2 mins off" → recovery
+
+    # Zone notation (already matches)
+    "z1": "z1 pace",
+    "z2": "z2 pace",
+    "z3": "z3 pace",
+    "z4": "z4 pace",
+    "z5": "z5 pace",
+}
+```
+
+#### 4. Structure rules
+```python
+def format_intervals(components):
+    """
+    Build Intervals.icu formatted string
+
+    Rules:
+    - Base run always first (if exists)
+    - Blank line before interval block
+    - Standalone "Nx" line
+    - Work + recovery steps with "-" prefix
+    - Blank line after interval block (if cooldown follows)
+    - NO nesting - flatten all intervals
+    """
+    lines = []
+
+    # Base run
+    if components.base_duration > 0:
+        lines.append(f"- {format_duration(components.base_duration)} {components.base_intensity}")
+        lines.append("")  # Blank line
+
+    # Interval block
+    if components.intervals:
+        lines.append(f"{components.reps}x")
+        lines.append(f"- {format_duration(components.work_duration)} {components.work_intensity}")
+        lines.append(f"- {format_duration(components.recovery_duration)} {components.recovery_intensity}")
+        lines.append("")  # Blank line after intervals
+
+    # Cooldown
+    if components.cooldown_duration > 0:
+        lines.append(f"- {format_duration(components.cooldown_duration)} {components.cooldown_intensity}")
+
+    return "\n".join(lines).strip()
+```
+
+### Format Specification Document Structure
+
+See `INTERVALS_FORMAT_SPEC.md` at repo root.
+
+### Testing Strategy
+
+#### Test cases
+```python
+TEST_CASES = [
+    {
+        "input": {
+            "description": "Easy running throughout 6-8x( 15-20s @ Stride / Fast (Z5) Full recovery easy jog )",
+            "duration_seconds": 2700  # 45 minutes
+        },
+        "expected_output": """- 18m z2 pace
+
+7x
+- 17s z5 pace
+- 1m45s z2 pace""",
+    },
+    {
+        "input": {
+            "description": "15:00 Easy (Z1-Z2) 2x( 10:00 @ HMP (Z4) 5:00 Walk / Easy Jog recovery ) 5:00 Easy (Z1-Z2)",
+            "duration_seconds": 2700  # 45 minutes
+        },
+        "expected_output": """- 15m z2 pace
+
+2x
+- 10m z4 pace
+- 5m z2 pace
+
+- 5m z2 pace""",
+    },
+    {
+        "input": {
+            "description": "30min easy",
+            "duration_seconds": 1800
+        },
+        "expected_output": "- 30m z2 pace",
+    },
+]
+```
+
+### Implementation Roadmap
+
+#### Phase 1 ✅ — Format specification document
+Create `INTERVALS_FORMAT_SPEC.md` at repo root.
+
+#### Phase 2 ✅ — Parser for common patterns
+- Parenthetical `Nx(work / recovery)` form
+- Inline `N x work [sep] recovery` prose form
+- Strides/pickups keyword template (5 × 15 s z5 / 1m45s z1)
+- Simple single-step fallback
+
+#### Phase 3 ✅ — Range resolution logic
+- Duration midpoint, rep midpoint-rounded-down
+- Intensity mapping table
+- `->` arrow notation (MP->HMP → z4)
+
+#### Phase 4 ✅ — Integration into MCP server
+- `create_event` and `bulk_create_events` call `translate_workout()` automatically
+- `translation_quality` field logged for observability
+
+#### Phase 5 — Deterministic bug fixes + Local LLM fallback (PLAN OF RECORD)
+
+**Status**: In design. These are the remaining known failure categories from
+the pre-marathon translation test (6 ✅ · 4 ⚠️ · 4 ❌).
+
+##### Phase 5a — Deterministic fixes (implement first, low risk)
+
+Four bugs with well-defined structural signatures that don't require an LLM:
+
+**P4 — `on`/`off` intensity mapping** (trivial)
+- Root cause: "30s on / 2 mins off" — `on` and `off` not in `INTENSITY_MAP`
+- Fix: Add `"on": "z5 pace"` and `"off": "z1 pace"` to the map
+- Risk: None
+
+**P3 — Non-bullet multi-segment descriptions**
+- Root cause: `45 mins easy\n30mins at MP\n15 mins cool down` (no `- ` prefix)
+  falls through `_parse_bullet_list` because it only matches `^-\s` lines
+- Fix: Add `_parse_plain_segments()` — iterate lines, call `_parse_step_fragment`
+  on each, accept result if ≥ 2 lines parse successfully; insert between bullet
+  check and inline check in `_translate()`
+- Risk: Very low
+
+**P2 — Commentary-bullet bleed**
+- Root cause: Coaching-cue bullets like `- By effort*`, `- Total Workout Time: 48 mins`,
+  `- Aim for 80-90 mins total` treated as workout steps
+- Fix: `_is_commentary_bullet(content)` filter applied in `_parse_bullet_list` before
+  step parsing:
+  ```python
+  _COMMENTARY_RE = re.compile(
+      r"^(by\s|total\s|aim\s|note[:\s]|start\s|priority\s|if\s|goal[:\s]|"
+      r"cool\s+down\s+to|hitting\s|practice\s)",
+      re.IGNORECASE,
+  )
+  _ARITHMETIC_RE = re.compile(r"\d+\s*\w+\s*\+\s*\d+")  # "20 easy + 48 w/o"
+
+  def _is_commentary_bullet(content: str) -> bool:
+      if _COMMENTARY_RE.match(content):
+          return True
+      if _ARITHMETIC_RE.search(content):
+          return True
+      return False
+  ```
+- Risk: Low; keyword list scoped to observed coach format patterns
+
+**P1 — `m` = meters vs minutes disambiguation**
+- Root cause: `200m`, `400m`, `800m`, `1600m` parsed as 200–1600 minutes
+- Fix: magnitude-based pre-filter `_is_meters_not_minutes(value)`:
+  ```python
+  _METER_DISTANCES = {100, 150, 200, 300, 400, 600, 800, 1000, 1200, 1500, 1600, 3000, 5000}
+  _MINUTE_THRESHOLD = 90  # Xm where X > 90 is never a valid minute count
+
+  def _is_meters_not_minutes(value: float) -> bool:
+      v = int(value)
+      return v in _METER_DISTANCES or v > _MINUTE_THRESHOLD
+  ```
+  When a token is identified as meters, return `None` for duration; bubble up as
+  `WorkoutTranslationError("distance-based intervals")` so it falls through to
+  Phase 5b LLM.
+- Risk: Very low; threshold of 90 min is safe for all realistic step durations
+
+##### Phase 5b — Local LLM fallback (implement after 5a, benchmark against 5a)
+
+**Motivation**: After Phase 5a, the remaining hard failures are structurally
+ambiguous — multi-segment prose with no bullets, nested conditions, or novel
+formats the regex can't anticipate. A local LLM handles these without
+additional rule engineering.
+
+**Model candidates** (benchmarked for structured output reliability):
+
+| Model | Size (Q4) | Est. latency (CPU) | Notes |
+|-------|-----------|-------------------|-------|
+| Phi-3-mini-4k | ~2.2 GB | ~2–4 s | Best size/quality for structured output |
+| Mistral-7B-Instruct | ~4.1 GB | ~5–10 s | More robust on ambiguous prose |
+| Llama-3.2-3B-Instruct | ~2.0 GB | ~2–3 s | Strong instruction following for size |
+
+**Recommended starting point**: Phi-3-mini via `ollama`. Upgrade to Mistral-7B
+if output quality is insufficient on the benchmark set.
+
+**Runtime options**:
+- `ollama` (recommended): single `ollama serve` background process; Python
+  client via `requests` or `ollama` pip package; no GPU required
+- `llama-cpp-python`: direct embedding in the MCP process, no side process;
+  slightly more setup
+- `ctransformers`: fallback if llama-cpp-python has build issues on Windows
+
+**Prompt design**:
+```
+System:
+You are a workout translator. Convert FinalSurge workout descriptions to
+Intervals.icu plain-text format. Rules:
+- Steps start with "- " (dash space)
+- Duration: 30m, 15s, 1h, 1m30s (m = minutes, s = seconds, NOT meters)
+- Intensity: z1–z5 pace (z1=recovery, z2=easy, z3=tempo, z4=threshold/HMP, z5=hard/strides)
+- Repeat blocks: standalone "Nx" line, then steps, blank lines before/after
+- No nested repeats
+- Distance-based intervals (200m, 800m etc.): estimate step duration from total
+  workout time and rep count
+
+Return ONLY the formatted workout. No explanation.
+
+Example 1:
+Duration: 45m
+Description: Easy running throughout 6-8x( 15-20s @ Stride / Fast (Z5) Full recovery easy jog )
+Output:
+- 18m z2 pace
+
+7x
+- 17s z5 pace
+- 1m45s z2 pace
+
+Example 2:
+Duration: 1h20m
+Description: 8 x 4:00mins @MP->HMP and 2:00mins easy
+Output:
+- 32m z2 pace
+
+8x
+- 4m z4 pace
+- 2m z2 pace
+
+User:
+Duration: {total_duration}
+Description: {description}
+
+Output:
+```
+
+**Integration in `_translate()`**:
+```python
+def _translate(description, duration_seconds, sport_type):
+    try:
+        # ... Phase 1–4 regex pipeline ...
+    except WorkoutTranslationError as exc:
+        logger.info("Regex pipeline failed (%s), trying LLM fallback.", exc)
+        if _llm_available():
+            return _translate_with_llm(description, duration_seconds, sport_type)
+        logger.warning("LLM unavailable, returning simple fallback.")
+        return _build_simple(description, duration_seconds, sport_type)
+```
+
+**`translation_quality` values** (for observability):
+- `"structured"` — paren or inline Nx form parsed deterministically
+- `"template"` — strides/pickups template applied
+- `"bullet_list"` — multi-bullet list parsed
+- `"plain_segments"` — non-bullet multi-line parsed (Phase 5a)
+- `"llm"` — LLM fallback used (Phase 5b)
+- `"simple_fallback"` — neither pipeline succeeded
+
+##### Phase 5c — Benchmark: regex+LLM vs straight-to-LLM
+
+**Purpose**: Determine whether the regex pre-pipeline is worth maintaining
+long-term vs. routing everything through the LLM.
+
+**Validation test set**: The 10 structured runs immediately preceding the Feb 1
+half marathon, taken from `workout_translations.md`. These are the best test
+cases because they are the most complex workouts in the plan (peak training
+weeks) and all have known expected outputs from the earlier translation run.
+
+| Date | Workout | Key challenge |
+|------|---------|---------------|
+| 2026-01-24 | Last Workout! | Non-bullet multi-segment (P3) |
+| 2026-01-23 | Easy Run with Strides | Strides template |
+| 2026-01-20 | Cutdown | Distance-based (`1600m`, `1200m`, etc.) (P1) |
+| 2026-01-17 | Last Big Workout! | Non-bullet multi-segment (P3) |
+| 2026-01-16 | Easy Run w/Strides | Strides template |
+| 2026-01-14 | Easy Run w/4-6 strides | Strides keyword |
+| 2026-01-13 | 600s | Commentary-bullet bleed (P2) |
+| 2026-01-10 | Long Run with Pickups | `on`/`off` intensity (P4) |
+| 2026-01-08 | Tempo + Pickups | `on`/`off` intensity (P4) |
+| 2026-01-06 | Easy Run w/Strides | Strides template |
+
+This set covers all four P1–P4 bug categories plus the strides template,
+making it the minimum viable benchmark corpus.
+
+**Benchmark protocol**:
+1. Run both approaches (regex+LLM hybrid, straight-to-LLM) against all 10 workouts
+2. Metrics:
+   - **Correctness**: manual review; score each output 0/0.5/1 against expected
+   - **Speed**: wall-clock time per workout (seconds)
+   - **Total pipeline time**: for a realistic weekly sync (assume 8–12 workouts)
+3. Expected hypothesis: regex handles ~60% of workouts in <1ms each; LLM covers
+   the rest in ~3–8s; straight-to-LLM is simpler but ~3–8s for every workout
+   including the easy ones
+
+**Decision criteria**:
+- If straight-to-LLM correctness ≥ regex+LLM and total time is acceptable
+  (< 2 min for a full week sync), retire the regex pipeline and simplify
+- If regex+LLM is meaningfully faster AND comparably correct, keep hybrid
+- The regex pipeline is also the documentation of intent (what each format
+  pattern means), so has archival value even if LLM wins on correctness alone
+
+##### Phase 5d — Future: structured output enforcement
+
+If the LLM produces occasional format violations (missing dash, wrong duration
+unit), add a lightweight post-processor that validates the output against
+`INTERVALS_FORMAT_SPEC.md` rules and either auto-corrects or re-prompts once.
+
+### Function Location in MCP Server
+
+```
+src/intervals_icu_mcp/
+├── workout_translator.py      # Regex pipeline + LLM dispatch
+├── workout_translator_llm.py  # LLM fallback (Phase 5b)
+└── tools/
+tests/
+├── test_translator.py
+└── test_translator_llm.py     # Phase 5b/5c benchmarks
+```
+
+### API Changes
+
+**New optional parameter on create_event**:
+```python
+def create_event(
+    ...,
+    auto_translate: bool = True,
+    ...
+):
+    if auto_translate and description:
+        description = translate_workout(description, duration_seconds, event_type)
+    # ... rest of implementation
+```
+
+### Edge Cases to Handle
+
+1. **Ambiguous ranges**: "6-8x" → default to midpoint rounded down (7x)
+2. **Missing intensity**: default to z2 for base, z2 for recovery
+3. **"Full recovery"**: calculate from remaining time
+4. **Nested parentheses**: flatten to single level
+5. **Multiple interval blocks**: NOT supported - fail with clear error
+6. **Unknown terms**: log warning, use conservative defaults
+7. **Distance-based intervals** (`200m`, `800m`): detected by magnitude heuristic,
+   routed to LLM fallback (Phase 5b) which can estimate duration from total time
+
+### Error Handling
+
+```python
+class WorkoutTranslationError(Exception):
+    """Raised when translation cannot proceed."""
+    pass
+
+def translate_workout(...):
+    try:
+        return _translate(...)
+    except WorkoutTranslationError as e:
+        logger.warning(f"Translation failed: {e}. Using original description.")
+        return description
+```
+
+### Documentation Updates Needed
+
+1. MCP tool description: Add `auto_translate` parameter docs
+2. README: Add translation examples
+3. Phase 5b: Add `ollama` setup instructions to README (model pull command,
+   background service setup on Windows)


### PR DESCRIPTION
## Summary

- `get_power_curves`, `get_hr_curves`, and `get_pace_curves` tools consistently returned empty data despite confirmed activity data existing on the athlete's account
- Root cause: the client was calling the wrong endpoints (`/power-curves`, `/hr-curves`, `/pace-curves`) which (a) don't accept an `oldest` date filter and (b) return a `DataCurveSet` shape — parallel `secs`/`values` arrays per named curve — that the existing pydantic models couldn't parse, so `data` was always silently `[]`
- Switched all three client methods to the `activity-*-curves` endpoints (`/activity-power-curves`, `/activity-hr-curves`, `/activity-pace-curves`), which accept `oldest`/`newest` for date-range filtering and return per-activity parallel arrays
- The client now aggregates per-activity arrays into a single best-effort list (max watts/bpm, min pace per duration) and reconstructs `DataCurvePt` objects that the existing tool logic already consumes correctly
- Also adds `DataCurvePt` to the client model imports

## Test plan

- [ ] `get_power_curves` with `activity_type: "Ride"` and `time_period: "month"` returns populated `peak_efforts` for an athlete with recent power data
- [ ] `get_power_curves` with `time_period: "all"` returns data across all time
- [ ] `get_hr_curves` returns populated data for an athlete with HR-recorded activities
- [ ] `get_pace_curves` returns populated data for an athlete with running activities
- [ ] All 77 existing tests continue to pass (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)